### PR TITLE
Revert "fix: only try and publish public cloud flavors"

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,4 +22,3 @@ glci:
           vars:
             PROMOTE_TARGET: "'release'"
             BUILD_TARGETS: "'build,build-baseimage,manifest,component-descriptor,publish,freeze-version'"
-            FLAVOUR_SET: "'public-clouds'"

--- a/flavours.yaml
+++ b/flavours.yaml
@@ -1,15 +1,5 @@
 ---
 flavour_sets:
-  - name: 'public-clouds'
-    flavour_combinations:
-      - architectures: [ 'amd64' ]
-        platforms: [ ali, aws, azure, gcp, openstack, vmware ]
-        modifiers: [ [ gardener, _prod ] ]
-        fails: [ unit, integration ]
-      - architectures: [ 'arm64' ]
-        platforms: [ aws ]
-        modifiers: [ [ gardener, _prod ] ]
-        fails: [ unit, integration ]
   - name: 'all'
     flavour_combinations:
       - architectures: [ 'amd64' ]


### PR DESCRIPTION
Reverts gardenlinux/glci#4