### PR TITLE
fix: only have public cloud flavours

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,4 +22,3 @@ glci:
           vars:
             PROMOTE_TARGET: "'release'"
             BUILD_TARGETS: "'build,build-baseimage,manifest,component-descriptor,publish,freeze-version'"
-            FLAVOUR_SET: "'public-clouds'"

--- a/flavours.yaml
+++ b/flavours.yaml
@@ -1,28 +1,10 @@
 ---
 flavour_sets:
-  - name: 'public-clouds'
-    flavour_combinations:
-      - architectures: [ 'amd64' ]
-        platforms: [ ali, aws, azure, gcp, openstack, vmware ]
-        modifiers: [ [ gardener, _prod ] ]
-        fails: [ unit, integration ]
-      - architectures: [ 'arm64' ]
-        platforms: [ aws ]
-        modifiers: [ [ gardener, _prod ] ]
-        fails: [ unit, integration ]
   - name: 'all'
     flavour_combinations:
       - architectures: [ 'amd64' ]
-        platforms: [ metal ]
-        modifiers: [ [ gardener, _prod ] , [ chost, _prod ] , [] ]
-        fails: [ unit, integration ]
-      - architectures: [ 'amd64' ]
         platforms: [ ali, aws, azure, gcp, openstack, vmware ]
         modifiers: [ [ gardener, _prod ] ]
-        fails: [ unit, integration ]
-      - architectures: [ 'amd64' ]
-        platforms: [ kvm ]
-        modifiers: [ ['_prod', 'chost'], ['_prod', 'gardener'] ]
         fails: [ unit, integration ]
       - architectures: [ 'arm64' ]
         platforms: [ aws ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Garden Linux CI pipeline should only publish to public clouds (and OpenStack) as there won't be release manifests for kvm and metal.

**Special notes for your reviewer**:

Must be merged after #4 is reverted in #5.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
