### PR TITLE
hack: force tuple in garden-feat call

### DIFF
--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -888,7 +888,7 @@ def _garden_feat(
     modifiers: typing.Tuple[str, ...],
     cmd: str,
 ) -> str:
-    all_mods = set(modifiers + (platform,))
+    all_mods = set(tuple(modifiers) + (platform,))
     garden_feat_binary = os.path.abspath(os.path.join(paths.gardenlinux_dir, 'bin', 'garden-feat'))
     completed = subprocess.run(
         args=[


### PR DESCRIPTION
**What this PR does / why we need it**:
This might be a temporary hack: force a tuple in the call to `garden_feat` so to avoid an error of concatenating a list and a tuple. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
hack: force tuple in garden-feat call
```
