### PR TITLE
Azure publishing for gen1, gen2 images and Marketplace

### DIFF
--- a/glci/alicloud.py
+++ b/glci/alicloud.py
@@ -96,18 +96,18 @@ class AlicloudImageMaker:
 
     # Import image from OSS and then copy it to other regions
     def make_image(self) -> glci.model.OnlineReleaseManifest:
-        image_id = self.import_image()
+        source_image_id = self.import_image()
         other_regions = self._list_regions()
         logger.info(f"begin to copy image to {other_regions=}")
         region_image_map = {}
         for region in other_regions:
-            region_image_map[region] = self.copy_image(image_id, region)
+            region_image_map[region] = self.copy_image(source_image_id, region)
 
         for region, image_id in region_image_map.items():
             self._wait_for_image(region, image_id)
             logger.info(f"finished copying {image_id=} to {region=}")
 
-        region_image_map[self.region] = image_id
+        region_image_map[self.region] = source_image_id
 
         self._share_images(region_image_map)
 
@@ -132,7 +132,6 @@ class AlicloudImageMaker:
             )
             req = ModifyImageSharePermissionRequest.ModifyImageSharePermissionRequest()
             req.set_ImageId(image_id)
-
 
             try:
                 req.set_IsPublic(True)

--- a/glci/model.py
+++ b/glci/model.py
@@ -330,13 +330,32 @@ class AzureTransportState(enum.Enum):
     FAILED = 'failed'
 
 
+class AzureHyperVGeneration(enum.Enum):
+    V1 = 'V1'
+    V2 = 'V2'
+
+
 @dataclasses.dataclass(frozen=True)
 class AzurePublishedImage:
-    '''
-    AzurePublishedImage hold information about the publishing process of an image
-    to the Azure Marketplace.
+    published_marketplace_images: typing.List[AzureMarketplacePublishedImage]
+    published_gallery_images: typing.List[AzureImageGalleryPublishedImage]
 
-    transport_state reflect the current stage of the image in the publishing process.
+
+@dataclasses.dataclass(frozen=True)
+class AzureImageGalleryPublishedImage:
+    '''
+    AzureImageGalleryPublishedImage holds information about images that were
+    published to Azure Community Image Galleries.
+    '''
+    hyper_v_generation: AzureHyperVGeneration
+    community_gallery_image_id : typing.Optional[str]
+
+
+@dataclasses.dataclass(frozen=True)
+class AzureMarketplacePublishedImage:
+    '''
+    AzureMarketplacePublishedImage hold information about the publishing process of an image
+    to the Azure Marketplace.
 
     urn is the image identfier used to spawn virtual machines with the image.
 
@@ -348,13 +367,10 @@ class AzurePublishedImage:
     to the Azure Marketplace. At the end of this process step the image is available
     in all Azure regions for general usage.
     '''
-
-    transport_state: AzureTransportState
+    hyper_v_generation: AzureHyperVGeneration
     publish_operation_id: str
     golive_operation_id: str
-    urn: typing.Optional[str]
-    community_gallery_image_id : typing.Optional[str]
-    id: typing.Optional[str]
+    urn: str
 
 
 @dataclasses.dataclass(frozen=True)
@@ -599,6 +615,7 @@ class AzureMarketplaceCfg:
     offer_id: str
     publisher_id: str
     plan_id: str
+    notification_emails: list[str]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -747,6 +764,9 @@ class PublishingTargetAzure:
     gallery_cfg_name: str
     storage_account_cfg_name: str
     service_principal_cfg_name: str
+    marketplace_cfg: AzureMarketplaceCfg
+    publish_to_marketplace: bool
+    publish_to_community_galleries: bool
     platform: Platform = 'azure' # should not overwrite
 
 

--- a/glci/util.py
+++ b/glci/util.py
@@ -155,6 +155,7 @@ def release_manifest(
                 typing.Tuple,
                 glci.model.TestResultCode,
                 glci.model.AzureTransportState,
+                glci.model.AzureHyperVGeneration,
             ],
         ),
     )
@@ -196,6 +197,7 @@ def release_manifest_set(
                 typing.Tuple,
                 glci.model.TestResultCode,
                 glci.model.AzureTransportState,
+                glci.model.AzureHyperVGeneration,
             ],
         ),
     )

--- a/publish.py
+++ b/publish.py
@@ -194,6 +194,9 @@ def _publish_azure_image(
         service_principal_cfg=azure_principal_serialized,
         storage_account_cfg=storage_account_cfg_serialized,
         shared_gallery_cfg=shared_gallery_cfg_serialized,
+        marketplace_cfg=azure_publishing_cfg.marketplace_cfg,
+        publish_to_community_gallery=azure_publishing_cfg.publish_to_community_galleries,
+        publish_to_marketplace=azure_publishing_cfg.publish_to_marketplace,
     )
 
 
@@ -294,12 +297,15 @@ def _publish_openstack_image(
 
 def _cleanup_openstack_image(
     release: gm.OnlineReleaseManifest,
-    cicd_cfg: gm.CicdCfg,
     publishing_cfg: gm.PublishingCfg,
 ):
     import glci.openstack_image
     import ci.util
-
+    
+    openstack_publishing_cfg: gm.PublishingTargetOpenstack = publishing_cfg.target(
+        platform=release.platform,
+    )
+    
     cfg_factory = ci.util.ctx().cfg_factory()
     openstack_environments_cfg = cfg_factory.ccee(
         openstack_publishing_cfg.environment_cfg_name,

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -29,6 +29,13 @@
       gallery_cfg_name: 'gardenlinux-community-gallery'
       storage_account_cfg_name: 'gardenlinux-community-gallery'
       service_principal_cfg_name: 'gardenlinux'
+      marketplace_cfg:
+        offer_id: 'gardenlinux'
+        publisher_id: 'sap'
+        plan_id: 'greatest'
+        notification_emails: ['thomas.buchner@sap.com','dirk.marwinski@sap.com','andre.russ@sap.com']
+      publish_to_marketplace: true
+      publish_to_community_galleries: true
     - platform: 'openstack'
       environment_cfg_name: 'gardenlinux'
       image_properties_cfg_name: 'gardenlinux'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces some changes to the Azure publishing code so that we have means to publish `gen1` and `gen2` as well as to optionally - based on configuration - publish to the Azure Marketplace (again).

In particular:
- introduce dedicated published images types for communityImageGalleries and Marketplace, each containing the images Hyper-V generation
- change the release manifest to contain list for published images on communityGalleries and Marketplace
- create a seperate gardenlinux-gen2 VM image definition for gen2 images in communityImageGalleries
- publish the image twice in gardenlinux and gardenlinux-gen2 VM image definitions to have the image available for both Hyper-V generations
- reenable the publishing code to Azure Marketplace
- configure publishing to Azure Marketplace and to Azure community image galleries through publishing-cfg.yaml

And in addition, some minor flaws in the OpenStack and Ali-Cloud publishing code were fixed on the way too.

**Special notes for your reviewer**:

This PR changes the `published_image_metadata` field of an Azure release manifest to accommodate `gen1` and `gen2` variants of the same Garden Linux image for Azure. 

Previously:
```yaml
published_image_metadata:
  community_gallery_image_id: /CommunityGalleries/gardenlinux-13e998fe-534d-4b0a-8a27-f16a73aef620/Images/gardenlinux/Versions/934.0.0
  golive_operation_id: ''
  id: ''
  publish_operation_id: ''
  transport_state: released
  urn: ''
```

Now:
```yaml
published_image_metadata:
  published_gallery_images:
  - community_gallery_image_id: /CommunityGalleries/gardenlinux-13e998fe-534d-4b0a-8a27-f16a73aef620/Images/gardenlinux/Versions/918.0.0
    hyper_v_generation: V1
  - community_gallery_image_id: /CommunityGalleries/gardenlinux-13e998fe-534d-4b0a-8a27-f16a73aef620/Images/gardenlinux-gen2/Versions/918.0.0
    hyper_v_generation: V2
  published_marketplace_images:
  - golive_operation_id: ''
    hyper_v_generation: V1
    publish_operation_id: ''
    urn: gardenlinux:greatest:918.0.0
  - golive_operation_id: ''
    hyper_v_generation: V2
    publish_operation_id: ''
    urn: gardenlinux:greatest-gen2:918.0.0
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
- allow publishing gen1 and gen2 images to community galleries
- optionally reenable publishing through the Azure Marketplace
```

```breaking operator
- structure of release manifest for Azure images changed to contain different variants of an image
```
