### PR TITLE
fix: remove spurious comma which accidentally creates a tuple of strings

### DIFF
--- a/glci/az.py
+++ b/glci/az.py
@@ -731,7 +731,7 @@ def publish_to_azure_marketplace(
     logger.info(f"Azure Marketplace publish operation ID is {publish_operation_id}")
 
     # use anticipated URN for now
-    urn=generate_urn(marketplace_cfg, published_version),
+    urn=generate_urn(marketplace_cfg, published_version)
     logger.info(f'Image shared on marketplace: {urn=}')
 
     marketplace_published_image = glci.model.AzureMarketplacePublishedImage(


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a typo (comma) which accidentally created a tuple of strings instead of a simple string in Azure URN info.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
fix: remove spurious comma which accidentally creates a tuple of strings
```
