### PR TITLE
cleanup function for GCP publishing

### DIFF
--- a/glci/gcp.py
+++ b/glci/gcp.py
@@ -51,6 +51,18 @@ def upload_image_to_gcp_store(
         return image_blob
 
 
+def delete_image_from_gcp_store(
+    storage_client: google.cloud.storage.Client,
+    release: glci.model.OnlineReleaseManifest,
+    publishing_cfg: glci.model.PublishingTargetGCP,
+):
+    gcp_bucket_name = publishing_cfg.gcp_bucket_name
+    image_blob_name = f'gardenlinux-{release.version}.tar.gz'
+
+    gcp_bucket = storage_client.get_bucket(gcp_bucket_name)
+    gcp_bucket.delete_blob(image_blob_name)
+
+
 def upload_image_from_gcp_store(
     compute_client,
     image_blob: google.cloud.storage.blob.Blob,
@@ -138,4 +150,16 @@ def upload_and_publish_image(
         image_blob=image_blob,
         gcp_project_name=gcp_project_name,
         release=release,
+    )
+
+
+def cleanup_image(
+    storage_client: google.cloud.storage.Client,
+    release: glci.model.OnlineReleaseManifest,
+    publishing_cfg: glci.model.PublishingTargetGCP,
+):
+    return delete_image_from_gcp_store(
+        storage_client=storage_client,
+        release=release,
+        publishing_cfg=publishing_cfg,
     )

--- a/glci/gcp.py
+++ b/glci/gcp.py
@@ -5,6 +5,7 @@ import logging
 
 import google.cloud.storage.blob
 import google.cloud.storage.client
+import googleapiclient.errors
 import glci.model
 import glci.util
 
@@ -51,7 +52,7 @@ def upload_image_to_gcp_store(
         return image_blob
 
 
-def delete_image_from_gcp_store(
+def delete_image_from_gcs_bucket(
     storage_client: google.cloud.storage.Client,
     release: glci.model.OnlineReleaseManifest,
     publishing_cfg: glci.model.PublishingTargetGCP,
@@ -60,7 +61,9 @@ def delete_image_from_gcp_store(
     image_blob_name = f'gardenlinux-{release.version}.tar.gz'
 
     gcp_bucket = storage_client.get_bucket(gcp_bucket_name)
-    gcp_bucket.delete_blob(image_blob_name)
+    image_blob = gcp_bucket.blob(image_blob_name)
+    if image_blob.exists():
+        image_blob.delete()
 
 
 def upload_image_from_gcp_store(
@@ -69,11 +72,7 @@ def upload_image_from_gcp_store(
     gcp_project_name: str,
     release: glci.model.OnlineReleaseManifest,
 ) -> glci.model.OnlineReleaseManifest:
-    image_name = f'gardenlinux-{release.canonical_release_manifest_key_suffix()}'.replace(
-        '.', '-'
-    ).replace(
-        '_', '-'
-    ).strip('-')
+    image_name = _get_image_name_from_release_manifest(release)
 
     images = compute_client.images()
 
@@ -87,6 +86,8 @@ def upload_image_from_gcp_store(
             },
         },
     )
+
+    logger().info(f'inserting new image {image_name=} into project {gcp_project_name=}')
 
     resp = insertion_rq.execute()
     op_name = resp['name']
@@ -130,6 +131,36 @@ def upload_image_from_gcp_store(
     return dataclasses.replace(release, published_image_metadata=published_image)
 
 
+def delete_image_from_gce_image_store(
+    compute_client,
+    gcp_project_name: str,
+    release: glci.model.OnlineReleaseManifest,
+) -> glci.model.OnlineReleaseManifest:
+    image_name = _get_image_name_from_release_manifest(release)
+
+    images = compute_client.images()
+
+    deletion_rq = images.delete(
+        project=gcp_project_name,
+        image=image_name,
+    )
+
+    logger().info(f'deleting stale image {image_name=} from project {gcp_project_name=}')
+
+    resp = deletion_rq.execute()
+    op_name = resp['name']
+
+    logger().info(f'waiting for {op_name=}')
+
+    operation = compute_client.globalOperations()
+    operation.wait(
+        project=gcp_project_name,
+        operation=op_name,
+    ).execute()
+
+    logger().info(f'image {image_name=} deleted')
+
+
 def upload_and_publish_image(
     storage_client: google.cloud.storage.Client,
     s3_client,
@@ -145,21 +176,56 @@ def upload_and_publish_image(
         publishing_cfg=publishing_cfg,
     )
 
-    return upload_image_from_gcp_store(
-        compute_client=compute_client,
-        image_blob=image_blob,
-        gcp_project_name=gcp_project_name,
-        release=release,
-    )
+    release_manifest = None
+
+    try:
+        release_manifest = upload_image_from_gcp_store(
+            compute_client=compute_client,
+            image_blob=image_blob,
+            gcp_project_name=gcp_project_name,
+            release=release,
+        )
+    except googleapiclient.errors.HttpError as e:
+        if e.status_code() == 409:
+            # image already exists, delete it first and retry
+            delete_image_from_gce_image_store(
+                compute_client=compute_client,
+                gcp_project_name=gcp_project_name,
+                release=release,
+            )
+            release_manifest = upload_image_from_gcp_store(
+                compute_client=compute_client,
+                image_blob=image_blob,
+                gcp_project_name=gcp_project_name,
+                release=release,
+            )
+
+    return release_manifest
 
 
 def cleanup_image(
     storage_client: google.cloud.storage.Client,
+    compute_client,
+    gcp_project_name: str,
     release: glci.model.OnlineReleaseManifest,
     publishing_cfg: glci.model.PublishingTargetGCP,
 ):
-    return delete_image_from_gcp_store(
+    delete_image_from_gce_image_store(
+        compute_client=compute_client,
+        gcp_project_name=gcp_project_name,
+        release=release,
+    )
+
+    delete_image_from_gcs_bucket(
         storage_client=storage_client,
         release=release,
         publishing_cfg=publishing_cfg,
     )
+
+
+def _get_image_name_from_release_manifest(release: glci.model.OnlineReleaseManifest) -> str:
+    return f'gardenlinux-{release.canonical_release_manifest_key_suffix()}'.replace(
+        '.', '-'
+    ).replace(
+        '_', '-'
+    ).strip('-')

--- a/publish.py
+++ b/publish.py
@@ -232,9 +232,11 @@ def _cleanup_gcp_image(
     cfg_factory = ci.util.ctx().cfg_factory()
     gcp_cfg = cfg_factory.gcp(gcp_publishing_cfg.gcp_cfg_name)
     storage_client = ccc.gcp.cloud_storage_client(gcp_cfg)
+    compute_client = ccc.gcp.authenticated_build_func(gcp_cfg)('compute', 'v1')
     
     return glci.gcp.cleanup_image(
         storage_client=storage_client,
+        compute_client=compute_client,
         release=release,
         publishing_cfg=gcp_publishing_cfg,
     )

--- a/publish.py
+++ b/publish.py
@@ -37,7 +37,7 @@ def publish_image(
         cleanup_function = _cleanup_aws
     elif release.platform == 'gcp':
         publish_function = _publish_gcp_image
-        cleanup_function = None
+        cleanup_function = _cleanup_gcp_image
     elif release.platform == 'azure':
         publish_function = _publish_azure_image
         cleanup_function = None
@@ -219,6 +219,22 @@ def _publish_gcp_image(
         s3_client=s3_client,
         compute_client=compute_client,
         gcp_project_name=gcp_cfg.project(),
+        release=release,
+        publishing_cfg=gcp_publishing_cfg,
+    )
+
+
+def _cleanup_gcp_image(
+    release: gm.OnlineReleaseManifest,
+    publishing_cfg: gm.PublishingCfg,
+) -> gm.OnlineReleaseManifest:
+    gcp_publishing_cfg: gm.PublishingTargetGCP = publishing_cfg.target(release.platform)
+    cfg_factory = ci.util.ctx().cfg_factory()
+    gcp_cfg = cfg_factory.gcp(gcp_publishing_cfg.gcp_cfg_name)
+    storage_client = ccc.gcp.cloud_storage_client(gcp_cfg)
+    
+    return glci.gcp.cleanup_image(
+        storage_client=storage_client,
         release=release,
         publishing_cfg=gcp_publishing_cfg,
     )


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements a cleanup function for GCP publishing that removes potentially stale images from GCE and leftover image blobs from GCS.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
A cleanup function for GCP publishing of Garden Linux was added to remove stale artefacts.
```
