### PR TITLE
fix: adapt glci to Garden Linux builder

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -29,15 +29,18 @@ glci:
       - name: 'GARDENLINUX'
         cfg_name: 'github_com'
         path: 'gardenlinux/gardenlinux'
-        branch: 'rel-934'
+        branch: 'main'
+      - name: 'GARDENLINUX_BUILDER'
+        cfg_name: 'github_com'
+        path: 'gardenlinux/builder'
+        branch: 'main'
       steps:
         publish-gardenlinux-images:
           execute:
-          - '../publish-release-set'
+          - '../run_publish_release_set.sh'
           - '--version-name'
           - 'default'
           image: 'eu.gcr.io/gardener-project/glci/job-image:0.1.0'
-
     update-job-image:
       repo:
         trigger: false

--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -759,7 +759,7 @@ def publish_release_set():
                     f'no cfg for {manifest.platform=} - aborting'
                 )
             else:
-                raise ValueError(ob_absent) # programming error
+                raise ValueError(on_absent) # programming error
 
     phase_logger.info('publishing-cfg was found to be okay - starting publishing now')
 

--- a/component_descriptor.py
+++ b/component_descriptor.py
@@ -217,7 +217,7 @@ def _image_rootfs_resource(
         ),
     ]
 
-    rootfs_file_path = release_manifest.path_by_suffix('.tar.xz')
+    rootfs_file_path = release_manifest.path_by_suffix('.tar')
 
     return cm.Resource(
         name='rootfs',

--- a/flavours.yaml
+++ b/flavours.yaml
@@ -1,0 +1,21 @@
+---
+flavour_sets:
+  - name: 'gardener'
+    flavour_combinations:
+      - architectures:
+        - amd64
+        platforms:
+        - ali
+        - aws
+        - azure
+        - gcp
+        - openstack
+        - vmware
+        modifiers:
+        - [ gardener, _prod ]
+      - architectures:
+        - arm64
+        platforms:
+        - aws
+        modifiers:
+        - [ gardener, _prod ]

--- a/glci/az.py
+++ b/glci/az.py
@@ -154,6 +154,7 @@ class AzmpOperationState(Enum):
     RUNNING = "running"
     COMPLETED = "completed"
     SUCCEEDED = "succeeded"
+    CANCELED = "canceled"
     FAILED = "failed"
 
 class AzmpTransportDest(Enum):
@@ -198,6 +199,9 @@ class AzureMarketplaceClient:
 
     def _raise_for_status(self, response, message=""):
         if response.ok:
+            return
+        if response.status_code == 409:
+            logger.warning(f"Conflicting Azure MP operation exists: {message}. statuscode={response.status_code}")
             return
         if message:
             raise RuntimeError(f"{message}. statuscode={response.status_code}")
@@ -551,16 +555,46 @@ def _create_shared_image(
     }
     regions.add(shared_gallery_cfg.location) # ensure that the gallery's location is present
     # rm regions not yet supported (although they are returned by the subscription-client)
-    regions.remove('australiacentral2')
-    regions.remove('brazilsoutheast')
-    regions.remove('francesouth')
-    regions.remove('germanynorth')
-    regions.remove('jioindiacentral')
-    regions.remove('norwaywest')
-    regions.remove('southafricawest')
-    regions.remove('switzerlandwest')
-    regions.remove('uaecentral')
-
+    try:
+        regions.remove('australiacentral2')
+    except KeyError:
+        pass
+    try:
+        regions.remove('brazilsoutheast')
+    except KeyError:
+        pass
+    try:
+        regions.remove('brazilus')
+    except KeyError:
+        pass
+    try:
+        regions.remove('francesouth')
+    except KeyError:
+        pass
+    try:
+        regions.remove('germanynorth')
+    except KeyError:
+        pass
+    try:
+        regions.remove('jioindiacentral')
+    except KeyError:
+        pass
+    try:
+        regions.remove('norwaywest')
+    except KeyError:
+        pass
+    try:
+        regions.remove('southafricawest')
+    except KeyError:
+        pass
+    try:
+        regions.remove('switzerlandwest')
+    except KeyError:
+        pass
+    try:
+        regions.remove('uaecentral')
+    except KeyError:
+        pass
 
     logger.info(f'Creating gallery image version {image_version=}')
     result: LROPoller[GalleryImageVersion] = cclient.gallery_image_versions.begin_create_or_update(

--- a/glci/util.py
+++ b/glci/util.py
@@ -18,6 +18,8 @@ import yaml
 import glci.model
 import paths
 
+import dacite.exceptions
+
 GardenlinuxFlavourSet = glci.model.GardenlinuxFlavourSet
 GardenlinuxFlavour = glci.model.GardenlinuxFlavour
 GardenlinuxFlavourCombination = glci.model.GardenlinuxFlavourCombination
@@ -146,19 +148,22 @@ def release_manifest(
     if not 'base_image' in parsed:
         parsed['base_image'] = None
 
-    manifest = dacite.from_dict(
-        data_class=glci.model.OnlineReleaseManifest,
-        data=parsed,
-        config=dacite.Config(
-            cast=[
-                glci.model.Architecture,
-                typing.Tuple,
-                glci.model.TestResultCode,
-                glci.model.AzureTransportState,
-                glci.model.AzureHyperVGeneration,
-            ],
-        ),
-    )
+    try:
+        manifest = dacite.from_dict(
+            data_class=glci.model.OnlineReleaseManifest,
+            data=parsed,
+            config=dacite.Config(
+                cast=[
+                    glci.model.Architecture,
+                    typing.Tuple,
+                    glci.model.TestResultCode,
+                    glci.model.AzureTransportState,
+                    glci.model.AzureHyperVGeneration,
+                ],
+            ),
+        )
+    except dacite.exceptions.UnionMatchError as e:
+        raise e
 
     return manifest
 
@@ -514,7 +519,7 @@ def vm_image_artefact_for_platform(platform: glci.model.Platform) -> str:
         'ali': '.qcow2',
         'aws': '.raw',
         'azure': '.vhd',
-        'gcp': '.tar.gz',
+        'gcp': '.gcpimage.tar.gz',
         'kvm': '.raw',
         'metal': '.tar.xz',
         'oci': '.tar.xz',

--- a/paths.py
+++ b/paths.py
@@ -10,7 +10,17 @@ else:
     gardenlinux_dir = os.path.join(parent_dir, 'gardenlinux')
 
 if not os.path.isdir(gardenlinux_dir):
-    print(f'ERROR: expected worktree of gardenlinux repo at {gardenlinux_candidates=}')
+    print(f'ERROR: expected worktree of gardenlinux repo at {gardenlinux_dir=}')
+    exit(1)
+
+if os.environ.get('GARDENLINUX_BUILDER_PATH'):
+    gardenlinux_builder_dir = os.path.abspath(os.environ.get('GARDENLINUX_BUILDER_PATH'))
+else:
+    # hack: assume local user has a copy of gardenlinux-repo as sibling to this repo
+    gardenlinux_builder_dir = os.path.join(parent_dir, 'gardenlinux-builder')
+
+if not os.path.isdir(gardenlinux_builder_dir):
+    print(f'ERROR: expected worktree of gardenlinux builder repo at {gardenlinux_builder_dir=}')
     exit(1)
 
 cicd_cfg_path = os.path.join(repo_root, 'cicd.yaml')
@@ -18,5 +28,5 @@ publishing_cfg_path = os.path.join(repo_root, 'publishing-cfg.yaml')
 publishing_versions_path = os.path.join(repo_root, 'publishing-versions.yaml')
 package_alias_path = os.path.join(repo_root, 'package_aliases.yaml')
 
-flavour_cfg_path = os.path.join(gardenlinux_dir, 'flavours.yaml')
+flavour_cfg_path = os.path.join(repo_root, 'flavours.yaml')
 version_path = os.path.join(repo_root, 'VERSION')

--- a/publish.py
+++ b/publish.py
@@ -237,6 +237,7 @@ def _cleanup_gcp_image(
     return glci.gcp.cleanup_image(
         storage_client=storage_client,
         compute_client=compute_client,
+        gcp_project_name=gcp_cfg.project(),
         release=release,
         publishing_cfg=gcp_publishing_cfg,
     )

--- a/publishing-versions.yaml
+++ b/publishing-versions.yaml
@@ -3,5 +3,5 @@
 # use `ls-manifests` command to find available version/commit-combinations
 # pipeline-job (.ci/pipeline_definitions) references named versions from this file
 - name: 'default'
-  version: '934.9'
-  commit: '54c63e5'
+  version: '1200.0'
+  commit: 'ac4d82e'

--- a/replicate.py
+++ b/replicate.py
@@ -11,6 +11,8 @@ import model
 import glci.model as gm
 import glci.util as gu
 
+from glci.aws import response_ok
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,6 +28,7 @@ def replicate_image_blobs(
     s3_source_client = s3_source_session.client('s3')
 
     for target_bucket in target_buckets:
+        logger.info(f'Performing image blob replication from {source_bucket.aws_cfg_name=} to {target_bucket.aws_cfg_name=}')
         s3_target_session = ccc.aws.session(target_bucket.aws_cfg_name)
         s3_target_client = s3_target_session.client('s3')
 
@@ -83,27 +86,29 @@ def replicate_image_blobs(
                 body = resp['Body']
 
 
-                logger.info(f'uploading to {target_bucket.bucket_name=}, {image_blob_ref.s3_key=}')
+                logger.info(f'uploading to {target_bucket.bucket_name=} for {target_bucket.aws_cfg_name=}, {image_blob_ref.s3_key=}')
                 logger.info(f'.. this may take a couple of minutes ({leng} octets)')
                 s3_target_client.upload_fileobj(
                     Fileobj=body,
                     Bucket=target_bucket.bucket_name,
                     Key=image_blob_ref.s3_key,
                     Config=bt.TransferConfig(
+                        use_threads=True,
+                        max_concurrency=5
                     ),
                 )
             except Exception as e:
-                logger.warning(f'there was an error trying to replicate using streaming')
+                logger.warning(f'there was an error trying to replicate using streaming: {e}')
                 logger.info('falling back to tempfile-backed replication')
 
                 with tempfile.TemporaryFile() as tf:
-                    s3_source_client.download_fileobj(
+                    response_ok(s3_source_client.download_fileobj(
                         Bucket=source_bucket.bucket_name,
                         Key=image_blob_ref.s3_key,
                         Fileobj=tf,
-                    )
+                    ))
                     logger.info('downloaded to tempfile - now starting to upload (2nd attempt)')
-                    s3_target_client.upload_fileobj(
+                    response_ok(s3_target_client.upload_fileobj(
                         Fileobj=body,
                         Bucket=target_bucket.bucket_name,
                         Key=image_blob_ref.s3_key,
@@ -112,13 +117,15 @@ def replicate_image_blobs(
                             # rationale: we sometimes see "sporadic"
                             # connectivity issues when uploading through "great
                             # chinese firewall"
+                            use_threads=True,
+                            max_concurrency=5
                         ),
-                    )
+                    ))
 
 
             # make it world-readable (otherwise, vm-image-imports may fail)
-            s3_target_client.put_object_acl(
+            response_ok(s3_target_client.put_object_acl(
                 ACL='public-read',
                 Bucket=target_bucket.bucket_name,
                 Key=image_blob_ref.s3_key,
-            )
+            ))

--- a/run_publish_release_set.sh
+++ b/run_publish_release_set.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+pip install networkx
+
+"$MAIN_REPO_DIR/publish-release-set" "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:

With the advent of the Garden Linux builder, the ways glci must interact with the Garden Linux repo and its build pipeline has changed yet again - those changes are addressed in this PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The glci publishing gear is adapted and updated to work with the new Garden Linux builder.
```
