### PR TITLE
fix: be more presistent when replicating to AWS CN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 __pycache__
+/dev

--- a/glci/gcp.py
+++ b/glci/gcp.py
@@ -96,10 +96,11 @@ def upload_image_from_gcp_store(
 
     operation = compute_client.globalOperations()
     
-    # this can take than two minutes, so we allow up to 2 minutes
+    # this can take more than two minutes, so we allow up to 20 minutes
+    max_retries = 10
     logger().info("waiting up to 20 minutes for image insert operation to complete")
 
-    for _ in range(10):
+    for retry in range(max_retries):
         try:
             operation.wait(
                 project=gcp_project_name,
@@ -107,7 +108,10 @@ def upload_image_from_gcp_store(
             ).execute()
             break
         except TimeoutError as e:
-            pass
+            if retry + 1 >= max_retries:
+                raise e
+            else:
+                pass
 
     logger().info(f'import done - removing temporary object from bucket {image_blob.name=}')
 

--- a/replicate.py
+++ b/replicate.py
@@ -93,6 +93,8 @@ def replicate_image_blobs(
                     Bucket=target_bucket.bucket_name,
                     Key=image_blob_ref.s3_key,
                     Config=bt.TransferConfig(
+                        use_threads=True,
+                        max_concurrency=5
                     ),
                 )
             except Exception as e:
@@ -100,23 +102,39 @@ def replicate_image_blobs(
                 logger.info('falling back to tempfile-backed replication')
 
                 with tempfile.TemporaryFile() as tf:
-                    response_ok(s3_source_client.download_fileobj(
+                    s3_source_client.download_fileobj(
                         Bucket=source_bucket.bucket_name,
                         Key=image_blob_ref.s3_key,
                         Fileobj=tf,
-                    ))
-                    logger.info('downloaded to tempfile - now starting to upload (2nd attempt)')
-                    response_ok(s3_target_client.upload_fileobj(
-                        Fileobj=body,
-                        Bucket=target_bucket.bucket_name,
-                        Key=image_blob_ref.s3_key,
-                        Config=bt.TransferConfig(
-                            num_download_attempts=20, # be very persistent before giving up
-                            # rationale: we sometimes see "sporadic"
-                            # connectivity issues when uploading through "great
-                            # chinese firewall"
-                        ),
-                    ))
+                    )
+                    logger.info('downloaded to tempfile')
+                    
+                    max_attempts = 20
+
+                    for attempt in range(max_attempts):
+                        logger.info(f'uploading to S3 into {target_bucket.bucket_name} - attempt {attempt} of {max_attempts}...')
+                        try:
+                            s3_target_client.upload_fileobj(
+                                Fileobj=body,
+                                Bucket=target_bucket.bucket_name,
+                                Key=image_blob_ref.s3_key,
+                                Config=bt.TransferConfig(
+                                    use_threads=True,
+                                    max_concurrency=5,
+                                    num_download_attempts=20, # be very persistent before giving up
+                                    # rationale: we sometimes see "sporadic"
+                                    # connectivity issues when uploading through "great
+                                    # chinese firewall"
+                                ),
+                            )
+                            break  # if we got here, it means the above instruction succeeded without exception and we can exit the retry-loop
+                        except botocore.exceptions.ReadTimeoutError as e:
+                            if attempt + 1 >= max_attempts:
+                                logger.error(f"Failed to upload to S3 within {max_attempts} attempts.")
+                                raise e
+                            else:
+                                logger.warning(f"Failed to upload to S3 during the {attempt} attempt, retrying...")
+                                continue
 
 
             # make it world-readable (otherwise, vm-image-imports may fail)


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces an additional loop to be more persistent and more resilient against connection problems to AWS CN.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
An additional loop to be more persistent and more resilient against connection problems to AWS CN is introduced into the GL publishing gear.
```
