### PR TITLE
fix: ignore errors when rm AZ publishing regions

### DIFF
--- a/glci/az.py
+++ b/glci/az.py
@@ -506,6 +506,11 @@ def _append_hyper_v_generation(s: str, generation: glci.model.AzureHyperVGenerat
         return f"{s}-gen2"
     return s
 
+def _remove_single_region_from_set(region_set: set, region: str):
+    try:
+        region_set.remove(region)
+    except KeyError:
+        pass
 
 def _create_shared_image(
     cclient: ComputeManagementClient,
@@ -551,15 +556,15 @@ def _create_shared_image(
     }
     regions.add(shared_gallery_cfg.location) # ensure that the gallery's location is present
     # rm regions not yet supported (although they are returned by the subscription-client)
-    regions.remove('australiacentral2')
-    regions.remove('brazilsoutheast')
-    regions.remove('francesouth')
-    regions.remove('germanynorth')
-    regions.remove('jioindiacentral')
-    regions.remove('norwaywest')
-    regions.remove('southafricawest')
-    regions.remove('switzerlandwest')
-    regions.remove('uaecentral')
+    _remove_single_region_from_set(regions, 'australiacentral2')
+    _remove_single_region_from_set(regions, 'brazilsoutheast')
+    _remove_single_region_from_set(regions, 'francesouth')
+    _remove_single_region_from_set(regions, 'germanynorth')
+    _remove_single_region_from_set(regions, 'jioindiacentral')
+    _remove_single_region_from_set(regions, 'norwaywest')
+    _remove_single_region_from_set(regions, 'southafricawest')
+    _remove_single_region_from_set(regions, 'switzerlandwest')
+    _remove_single_region_from_set(regions, 'uaecentral')
 
 
     logger.info(f'Creating gallery image version {image_version=}')

--- a/replicate.py
+++ b/replicate.py
@@ -112,7 +112,7 @@ def replicate_image_blobs(
                     max_attempts = 20
 
                     for attempt in range(max_attempts):
-                        logger.info(f'uploading to S3 into {target_bucket.bucket_name} - attempt {attempt} of {max_attempts}...')
+                        logger.info(f'uploading to S3 into {target_bucket.bucket_name} - attempt {attempt + 1} of {max_attempts}...')
                         try:
                             s3_target_client.upload_fileobj(
                                 Fileobj=body,
@@ -128,12 +128,12 @@ def replicate_image_blobs(
                                 ),
                             )
                             break  # if we got here, it means the above instruction succeeded without exception and we can exit the retry-loop
-                        except botocore.exceptions.ReadTimeoutError as e:
+                        except (botocore.exceptions.ReadTimeoutError, botocore.exceptions.IncompleteReadError) as e:
                             if attempt + 1 >= max_attempts:
                                 logger.error(f"Failed to upload to S3 within {max_attempts} attempts.")
                                 raise e
                             else:
-                                logger.warning(f"Failed to upload to S3 during the {attempt} attempt, retrying...")
+                                logger.warning(f"Failed to upload to S3 during the {attempt + 1} attempt, retrying...")
                                 continue
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When removing publishing regions from the list of available regions in Azure, the publishing gear should not error out if a region that does not exist is attempted to be removed - this can safely be ignored.
As a followup to #17, we must catch `botocore.exceptions.IncompleteReadErrors` as well.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
An error that causes the publishing gear to fail when it attempts to remove a non-existing region from the list of Azure publishing regions was fixed.
```
