### PR TITLE
Replace usage of product.v2 with cnudie

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -15,9 +15,9 @@ import yaml
 import component_descriptor as cd
 import publish
 import replicate
-import product.v2
 
 import ccc.aws
+import cnudie.upload
 import ctx
 
 logger = logging.getLogger('gardenlinux-cli')
@@ -836,8 +836,8 @@ def publish_release_set():
         pprint.pprint(component_descriptor)
 
     phase_logger.info('publishing component-descriptor')
-    product.v2.upload_component_descriptor_v2_to_oci_registry(
-        component_descriptor_v2=component_descriptor,
+    cnudie.upload.upload_component_descriptor(
+        component_descriptor=component_descriptor,
     )
 
     end_phase(phase_component_descriptor)

--- a/github_release.py
+++ b/github_release.py
@@ -2,9 +2,11 @@ import os
 
 from string import Template
 
+import gci.componentmodel as cm
+
 import ctx
 import glci.model
-import product.v2
+import cnudie.retrieve
 import release
 
 
@@ -222,12 +224,15 @@ def make_release(
     cfg = f.ctx_repository(ctx_repository_config_name)
     ctx_repo_base_url = cfg.base_url()
 
-    comp_descr = product.v2.download_component_descriptor_v2(
-        component_name='github.com/gardenlinux/gardenlinux',
-        component_version=version,
-        ctx_repo_base_url=ctx_repo_base_url,
-        cache_dir=None,
+    lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+        default_ctx_repo=cm.OciRepositoryContext(base_url=ctx_repo_base_url)
     )
+
+    comp_descr = lookup(cm.ComponentIdentity(
+        name='github.com/gardenlinux/gardenlinux',
+        version=version,
+
+    ))
 
     with open(os.path.join(repo_dir, 'component-descriptor'), 'w') as out_file:
         comp_descr.to_fobj(out_file)

--- a/steps/component_descriptor.py
+++ b/steps/component_descriptor.py
@@ -10,9 +10,9 @@ import glci.model
 import glci.s3
 import glci.util
 
+import cnudie.upload
 import ctx
 import gci.componentmodel as cm
-import product.v2
 import version as version_util
 
 logger = logging.getLogger(__name__)
@@ -183,9 +183,9 @@ def build_component_descriptor(
     )
 
     if glci.model.BuildTarget.COMPONENT_DESCRIPTOR in build_target_set:
-        product.v2.upload_component_descriptor_v2_to_oci_registry(
-            component_descriptor_v2=component_descriptor,
-            on_exist=product.v2.UploadMode.OVERWRITE,
+        cnudie.upload.upload_component_descriptor(
+            component_descriptor=component_descriptor,
+            on_exist=cnudie.upload.UploadMode.OVERWRITE,
         )
 
     if snapshot_repo_base_url:
@@ -197,9 +197,9 @@ def build_component_descriptor(
             component_descriptor.component.repositoryContexts.append(repo_ctx)
 
         # upload obeys the appended repo_ctx
-        product.v2.upload_component_descriptor_v2_to_oci_registry(
-            component_descriptor_v2=component_descriptor,
-            on_exist=product.v2.UploadMode.OVERWRITE,
+        cnudie.upload.upload_component_descriptor(
+            component_descriptor=component_descriptor,
+            on_exist=cnudie.upload.UploadMode.OVERWRITE,
         )
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
removes usage of the deprecated product.v2 package and replaces it with usage of the cnudie-package.
