### PR TITLE
enable publishing for OpenStack baremetal

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -645,7 +645,6 @@ def publish_release_set():
     cfg_factory = ctx.cfg_factory()
 
     flavour_set = _flavourset(parsed)
-    flavours = tuple(flavour_set.flavours())
 
     if len(commit) != 40:
         repo = git.Repo(path=paths.gardenlinux_dir)

--- a/glci/model.py
+++ b/glci/model.py
@@ -751,9 +751,19 @@ class PublishingTargetAzure:
 @dataclasses.dataclass
 class PublishingTargetOpenstack:
     environment_cfg_name: str
-    image_properties_cfg_name: str
+    image_properties: typing.Optional[dict[str, str]]
+    suffix: typing.Optional[str]
     platform: Platform = 'openstack' # should not overwrite
 
+@dataclasses.dataclass
+class PublishingTargetOpenstackBareMetal(PublishingTargetOpenstack):
+    platform: Platform = 'openstackbaremetal' # should not overwrite
+
+
+@dataclasses.dataclass
+class OpenStackImageProperties:
+    hypervisor_type: str
+    openstack_properties: dict[str, str]
 
 @dataclasses.dataclass
 class OcmCfg:
@@ -995,7 +1005,9 @@ def platform_names():
 
 def modifiers():
     return {
-        feature for feature in features() if feature.type is FeatureType.MODIFIER
+        # HACK: including metal here is a terrible hack to get the openstackbaremetal flavour out
+        # this needs to be fixed on Garden Linux side by making metal a modifier, not a platform
+        feature for feature in features() if feature.type is FeatureType.MODIFIER or feature.name == 'metal'
     }
 
 

--- a/glci/openstack_image.py
+++ b/glci/openstack_image.py
@@ -108,10 +108,14 @@ def upload_and_publish_image(
     openstack_environments_cfgs: typing.Tuple[glci.model.OpenstackEnvironment],
     image_properties: dict,
     release: glci.model.OnlineReleaseManifest,
+    suffix: str = None,
 ) -> glci.model.OnlineReleaseManifest:
     """Import an image from S3 into OpenStack Glance."""
 
     image_name = f"gardenlinux-{release.version}"
+    if suffix and len(suffix) > 0:
+        image_name = f"{image_name}-{suffix}"
+
     image_meta = {
         'architecture': release.architecture.name,
         'properties': image_properties,

--- a/glci/util.py
+++ b/glci/util.py
@@ -524,6 +524,7 @@ def vm_image_artefact_for_platform(platform: glci.model.Platform) -> str:
         'metal': '.tar.xz',
         'oci': '.tar.xz',
         'openstack': '.vmdk',
+        'openstackbaremetal': '.vmdk',
         'vmware': '.ova',
     }
 

--- a/publish.py
+++ b/publish.py
@@ -44,6 +44,9 @@ def publish_image(
     elif release.platform == 'openstack':
         publish_function = _publish_openstack_image
         cleanup_function = _cleanup_openstack_image
+    elif release.platform == 'openstackbaremetal':
+        publish_function = _publish_openstack_image
+        cleanup_function = _cleanup_openstack_image
     elif release.platform == 'oci':
         publish_function = _publish_oci_image
         cleanup_function = None
@@ -291,10 +294,6 @@ def _publish_openstack_image(
     username = openstack_environments_cfg.credentials().username()
     password = openstack_environments_cfg.credentials().passwd()
 
-    image_properties = cfg_factory.openstack_os_image(
-        openstack_publishing_cfg.image_properties_cfg_name,
-    ).raw['properties']
-
     openstack_env_cfgs = tuple((
         gm.OpenstackEnvironment(
             project_name=project.name(),
@@ -306,11 +305,14 @@ def _publish_openstack_image(
         ) for project in openstack_environments_cfg.projects()
     ))
 
+    image_properties = openstack_publishing_cfg.image_properties
+
     return glci.openstack_image.upload_and_publish_image(
         s3_client,
         openstack_environments_cfgs=openstack_env_cfgs,
         image_properties=image_properties,
         release=release,
+        suffix=openstack_publishing_cfg.suffix
     )
 
 

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -38,4 +38,17 @@
       publish_to_community_galleries: true
     - platform: 'openstack'
       environment_cfg_name: 'gardenlinux'
-      image_properties_cfg_name: 'gardenlinux'
+      image_properties:
+        hypervisor_type: vmware
+        vmware_ostype: debian10_64Guest
+        hw_vif_model: vmxnet3
+        hw_disk_bus: scsi
+        vmware_adaptertype: paraVirtual
+        vmware_disktype: streamOptimized
+    - platform: 'openstackbaremetal'
+      environment_cfg_name: 'gardenlinux'
+      suffix: 'baremetal'
+      image_properties:
+        hypervisor_type: baremetal
+        os_distro: debian10_64Guest
+        img_config_drive: mandatory


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables the publishing gear to publish Garden Linux image to OpenStack for bare-metal images (and a dedicated set of image properties).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The glci publishing gear can now publish bare-metal images to OpenStack/CCEE.
```
