### PR TITLE
reenable publishing to Az Marketplace

### DIFF
--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -34,7 +34,7 @@
         publisher_id: 'sap'
         plan_id: 'greatest'
         notification_emails: ['thomas.buchner@sap.com','dirk.marwinski@sap.com','andre.russ@sap.com']
-      publish_to_marketplace: false
+      publish_to_marketplace: true
       publish_to_community_galleries: true
     - platform: 'openstack'
       environment_cfg_name: 'gardenlinux'


### PR DESCRIPTION
**What this PR does / why we need it**:

This enables the publishing gear to publish to Az Marketplace in addition to Az Community Galleries. Required until some minor hickups we experienced with Az Community Galleries are fixed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
