### PR TITLE
Add support for Gardener pre-release integration test pipeline

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -891,8 +891,15 @@ def publish_release_set():
         pprint.pprint(component_descriptor)
 
     phase_logger.info('publishing component-descriptor')
+
+    if cfg.ocm.overwrite_compnent_descriptor:
+        on_exist=cnudie.upload.UploadMode.OVERWRITE
+    else:
+        on_exist=cnudie.upload.UploadMode.SKIP
+
     cnudie.upload.upload_component_descriptor(
         component_descriptor=component_descriptor,
+        on_exist=on_exist
     )
 
     end_phase(phase_component_descriptor)

--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -755,7 +755,7 @@ def publish_release_set():
 
     source_manifest_bucket = cfg.source_manifest_bucket
     target_manifest_buckets = tuple(cfg.target_manifest_buckets)
-    if len(target_manifest_buckets) == 0:
+    if not target_manifest_buckets:
         target_manifest_buckets = (source_manifest_bucket,)
 
     s3_session = ccc.aws.session(source_manifest_bucket.aws_cfg_name)

--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -13,8 +13,6 @@ import sys
 import yaml
 
 import component_descriptor as cd
-import publish
-import replicate
 
 import ccc.aws
 import cnudie.upload
@@ -442,6 +440,8 @@ def _publishing_cfg(parsed):
 
 
 def replicate_blobs():
+    import replicate    # late import because unneeded for the other functions
+
     parser = argparse.ArgumentParser()
     _add_flavourset_args(parser)
     _add_publishing_cfg_args(parser)
@@ -585,6 +585,9 @@ def ls_manifests():
 
 
 def publish_release_set():
+    import publish      # late import because unneeded for the other funtions
+    import replicate    # late import because unneeded for the other funtions
+
     parser = argparse.ArgumentParser(
         description='run all sub-steps for publishing gardenlinux to all target hyperscalers',
     )

--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -896,7 +896,7 @@ def publish_release_set():
     if parsed.print_component_descriptor:
         pprint.pprint(component_descriptor)
 
-    repository_context = component_descriptor.component.repositoryContexts[0].baseUrl
+    repository_context = component_descriptor.component.current_repository_ctx().baseUrl
     component_name = component_descriptor.component.name
     component_version = component_descriptor.component.version
 

--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -890,7 +890,12 @@ def publish_release_set():
     if parsed.print_component_descriptor:
         pprint.pprint(component_descriptor)
 
+    repository_context = component_descriptor.component.repositoryContexts[0].baseUrl
+    component_name = component_descriptor.component.name
+    component_version = component_descriptor.component.version
+
     phase_logger.info('publishing component-descriptor')
+    phase_logger.info(f'{repository_context=} {component_name=} {component_version=}')
 
     if cfg.ocm.overwrite_compnent_descriptor:
         on_exist=cnudie.upload.UploadMode.OVERWRITE

--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -576,7 +576,7 @@ def ls_manifests():
                 committish=m.committish
             )
             with open(parsed.yaml[0], "w") as f:
-                f.write(yaml.dump(v.__dict__))
+                f.write(yaml.safe_dump(dataclasses.asdict(v)))
         else:
             print(f"{m.version} {m.committish}")
     else:

--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -511,7 +511,7 @@ def ls_manifests():
     parser.add_argument(
         '--print',
         default='all',
-        choices=('all', 'versions', 'versions-and-commits', 'latest'),
+        choices=('all', 'versions', 'versions-and-commits', 'greatest'),
     )
     parser.add_argument(
         '--yaml',
@@ -567,7 +567,7 @@ def ls_manifests():
 
     manifests.sort(key=lambda v: float(v.version))
 
-    if parsed.print == 'latest':
+    if parsed.print == 'greatest':
         m = manifests.pop()
         if parsed.yaml:
             v = glci.model.S3_ManifestVersion(

--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -18,6 +18,7 @@ import ccc.aws
 import cnudie.upload
 import cnudie.retrieve
 import ctx
+import version as cc_version
 
 logger = logging.getLogger('gardenlinux-cli')
 
@@ -565,7 +566,7 @@ def ls_manifests():
             )
             manifests.append(s)
 
-    manifests.sort(key=lambda v: float(v.version))
+    manifests.sort(key=lambda v: cc_version.greatest_version([cc_version.parse_to_semver(v.version)]))
 
     if parsed.print == 'greatest':
         m = manifests.pop()

--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -929,7 +929,7 @@ def cleanup_release_set():
         '--version',
     )
     parser.add_argument(
-        '--ctx-repo',
+        '--ocm-repo',
         help='the component-repo to retrieve gardenlinux-component-descriptor from',
         default=None,
         required=False,
@@ -977,11 +977,11 @@ def cleanup_release_set():
     cfg = _publishing_cfg(parsed)
     cfg_factory = ctx.cfg_factory()
 
-    if not parsed.ctx_repo:
+    if not parsed.ocm_repo:
         ocm_cfg = cfg_factory.ctx_repository(cfg.ocm.component_repository_cfg_name)
         ocm_repo_base_url = ocm_cfg.base_url()
     else:
-        ocm_repo_base_url = parsed.ctx_repo
+        ocm_repo_base_url = parsed.ocm_repo
 
     gardenlinux_component = cd.retrieve_component(
         ctx_repository=ocm_repo_base_url,

--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -984,11 +984,11 @@ def cleanup_release_set():
     else:
         ocm_repo_base_url = parsed.ocm_repo
 
-    gardenlinux_component = cd.retrieve_component(
-        ctx_repository=ocm_repo_base_url,
-        component_name='github.com/gardenlinux/gardenlinux',
-        component_version=version,
+    component_descriptor_lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(ocm_repo_base_url)
     )
+
+    gardenlinux_component = component_descriptor_lookup(('github.com/gardenlinux/gardenlinux', version)).component
 
     if parsed.print_component_descriptor:
         pp.pprint(gardenlinux_component)

--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -660,7 +660,7 @@ def publish_release_set():
         help='if --phase is given, skip previous phases (for debugging purposes)',
     )
     parser.add_argument(
-        "--infile",
+        "--version-file",
         nargs=1,
         help="read version and committish from given YAML file"
     )
@@ -670,7 +670,7 @@ def publish_release_set():
     version = None
     commit = None
 
-    if not bool(parsed.infile):
+    if not bool(parsed.version_file):
         if not bool(parsed.version) ^ bool(parsed.version_name):
             logger.fatal('exactly one of --version, --version-name must be passed')
             exit(1)
@@ -690,7 +690,7 @@ def publish_release_set():
             version = publish_version.version
             commit = publish_version.commit
     else:
-        with open(parsed.infile[0]) as f:
+        with open(parsed.version_file[0]) as f:
             input = yaml.safe_load(f)
             version = input['version']
             commit = input['committish']
@@ -958,21 +958,21 @@ def cleanup_release_set():
         default=False,
     )
     parser.add_argument(
-        "--infile",
+        "--version-file",
         nargs=1,
         help="read version from given YAML file"
     )
 
     parsed = parser.parse_args()
 
-    if bool(parsed.infile):
-        with open(parsed.infile[0]) as f:
+    if bool(parsed.version_file):
+        with open(parsed.version_file[0]) as f:
             input = yaml.safe_load(f)
             version = input['version']
     elif bool(parsed.version):
         version = parsed.version
     else:
-        raise RuntimeError(f"need to provide either --version or --infile parameter")
+        raise RuntimeError(f"need to provide either --version or --version-file parameter")
 
     cfg = _publishing_cfg(parsed)
     cfg_factory = ctx.cfg_factory()

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 __pycache__
+.DS_Store
 /dev

--- a/cleanup-release-set
+++ b/cleanup-release-set
@@ -1,0 +1,1 @@
+.cicd-cli.py

--- a/cleanup.py
+++ b/cleanup.py
@@ -168,8 +168,6 @@ def cleanup_openstack_images(
     )
 
 
-## functions moved over from clean.py
-
 def clean_release_manifest_sets(
     max_age_days: int=14,
     cicd_cfg=None,

--- a/cleanup.py
+++ b/cleanup.py
@@ -1,28 +1,186 @@
+#!/usr/bin/env python3
+
+import logging
+
+import functools
+import dataclasses
+import os
 import concurrent.futures
 import datetime
 import itertools
-import logging
-import os
 import typing
 
-import glci.model
-import glci.s3
+import glci.aws
+import glci.gcp
+import glci.model as gm
 import glci.util
+
+import ccc.aws
+import ccc.gcp
+
+import ci.util
 
 logger = logging.getLogger(__name__)
 
+def cleanup_image(
+    release: gm.OnlineReleaseManifest,
+    publishing_cfg: gm.PublishingCfg,
+    dry_run: bool,
+) -> gm.OnlineReleaseManifest:
+    logger.info(f'running release for {release.platform=}')
+
+    if release.platform == 'ali':
+        cleanup_function = None # clean_alicloud_images
+    elif release.platform == 'aws':
+        cleanup_function = cleanup_aws_images_by_id
+    elif release.platform == 'gcp':
+        cleanup_function = None # cleanup_gcp_images
+    elif release.platform == 'azure':
+        cleanup_function = None
+    elif release.platform == 'openstack':
+        cleanup_function = None # cleanup_openstack_images
+    elif release.platform == 'oci':
+        cleanup_function = None
+    else:
+        logger.warning(f'do not know how to clean up {release.platform=}, yet')
+        return release
+
+    try:
+        cleanup_function(release, publishing_cfg, dry_run)
+        if dry_run:
+            return release
+        else:
+            return dataclasses.replace(release, published_image_metadata=None)
+    except:
+        import traceback
+        traceback.print_exc()
+
+
+def cleanup_aws_images(
+    release: gm.OnlineReleaseManifest,
+    publishing_cfg: gm.PublishingCfg,
+    dry_run: bool = False
+):
+    target_image_name = glci.aws.target_image_name_for_release(release=release)
+    aws_publishing_cfg: gm.PublishingTargetAWS = publishing_cfg.target(platform=release.platform)
+
+    for aws_cfg in aws_publishing_cfg.aws_cfgs:
+        aws_cfg_name = aws_cfg.aws_cfg_name
+        mk_session = functools.partial(ccc.aws.session, aws_cfg=aws_cfg_name)
+        glci.aws.unregister_images_by_name(
+            mk_session=mk_session,
+            image_name=target_image_name,
+            dry_run=dry_run
+        )
+
+
+def cleanup_aws_images_by_id(
+    release: gm.OnlineReleaseManifest,
+    publishing_cfg: gm.PublishingCfg,
+    dry_run: bool
+):
+    aws_publishing_cfg: gm.PublishingTargetAWS = publishing_cfg.target(platform=release.platform)
+
+    for aws_cfg in aws_publishing_cfg.aws_cfgs:
+        aws_cfg_name = aws_cfg.aws_cfg_name
+        mk_session = functools.partial(ccc.aws.session, aws_cfg=aws_cfg_name)
+        glci.aws.unregister_images_by_id(
+            mk_session=mk_session,
+            images=release.published_image_metadata.published_aws_images,
+            dry_run=dry_run
+        )
+
+
+def clean_alicloud_images(
+    release: gm.OnlineReleaseManifest,
+    publishing_cfg: gm.PublishingCfg,
+) -> gm.OnlineReleaseManifest:
+    import ccc.alicloud
+    import glci.alicloud
+    aliyun_cfg = publishing_cfg.target(release.platform)
+    alicloud_cfg_name = aliyun_cfg.aliyun_cfg_name
+
+    oss_auth = ccc.alicloud.oss_auth(alicloud_cfg=alicloud_cfg_name)
+    acs_client = ccc.alicloud.acs_client(alicloud_cfg=alicloud_cfg_name)
+
+    maker = glci.alicloud.AlicloudImageMaker(
+        oss_auth,
+        acs_client,
+        release,
+        aliyun_cfg,
+    )
+
+    return maker.delete_images()
+
+
+def cleanup_gcp_images(
+    release: gm.OnlineReleaseManifest,
+    publishing_cfg: gm.PublishingCfg,
+) -> gm.OnlineReleaseManifest:
+    gcp_publishing_cfg: gm.PublishingTargetGCP = publishing_cfg.target(release.platform)
+    cfg_factory = ci.util.ctx().cfg_factory()
+    gcp_cfg = cfg_factory.gcp(gcp_publishing_cfg.gcp_cfg_name)
+    storage_client = ccc.gcp.cloud_storage_client(gcp_cfg)
+    compute_client = ccc.gcp.authenticated_build_func(gcp_cfg)('compute', 'v1')
+
+    return glci.gcp.cleanup_image(
+        storage_client=storage_client,
+        compute_client=compute_client,
+        gcp_project_name=gcp_cfg.project(),
+        release=release,
+        publishing_cfg=gcp_publishing_cfg,
+    )
+
+
+def cleanup_openstack_images(
+    release: gm.OnlineReleaseManifest,
+    publishing_cfg: gm.PublishingCfg,
+):
+    import glci.openstack_image
+    import ci.util
+
+    openstack_publishing_cfg: gm.PublishingTargetOpenstack = publishing_cfg.target(
+        platform=release.platform,
+    )
+
+    cfg_factory = ci.util.ctx().cfg_factory()
+    openstack_environments_cfg = cfg_factory.ccee(
+        openstack_publishing_cfg.environment_cfg_name,
+    )
+
+    username = openstack_environments_cfg.credentials().username()
+    password = openstack_environments_cfg.credentials().passwd()
+
+    openstack_env_cfgs = tuple((
+        gm.OpenstackEnvironment(
+            project_name=project.name(),
+            domain=project.domain(),
+            region=project.region(),
+            auth_url=project.auth_url(),
+            username=username,
+            password=password,
+        ) for project in openstack_environments_cfg.projects()
+    ))
+
+    glci.openstack_image.delete_images_for_release(
+        openstack_environments_cfgs=openstack_env_cfgs,
+        release=release,
+    )
+
+
+## functions moved over from clean.py
 
 def clean_release_manifest_sets(
     max_age_days: int=14,
     cicd_cfg=None,
     prefix: str=os.path.join(
-      glci.model.ReleaseManifestSet.release_manifest_set_prefix,
-      glci.model.PipelineFlavour.SNAPSHOT.value,
+      gm.ReleaseManifestSet.release_manifest_set_prefix,
+      gm.PipelineFlavour.SNAPSHOT.value,
     ),
     dry_run: bool=False,
 ):
     if not cicd_cfg:
-        cicd_cfg = glci.model.CicdCfg=glci.util.cicd_cfg()
+        cicd_cfg = gm.CicdCfg=glci.util.cicd_cfg()
     enumerate_release_sets = glci.util.preconfigured(
         glci.util.enumerate_release_sets,
         cicd_cfg=cicd_cfg,
@@ -36,7 +194,7 @@ def clean_release_manifest_sets(
 
     s3_client = glci.s3.s3_client(cicd_cfg=cicd_cfg)
 
-    def purge_if_outdated(release_manifest_set: glci.model.ReleaseManifestSet):
+    def purge_if_outdated(release_manifest_set: gm.ReleaseManifestSet):
         if len(release_manifest_set.manifests) < 1:
             logger.warning(f'{release_manifest_set.s3_key=} did not contain any manifests')
             return (False, release_manifest_set)
@@ -71,11 +229,11 @@ def clean_release_manifest_sets(
 def clean_single_release_manifests(
     max_age_days: int=14,
     cicd_cfg=None,
-    prefix: str=glci.model.ReleaseManifest.manifest_key_prefix,
+    prefix: str=gm.ReleaseManifest.manifest_key_prefix,
     dry_run: bool=False,
 ):
     if not cicd_cfg:
-        cicd_cfg = glci.model.CicdCfg=glci.util.cicd_cfg()
+        cicd_cfg = gm.CicdCfg=glci.util.cicd_cfg()
 
     enumerate_releases = glci.util.preconfigured(
         glci.util.enumerate_releases,
@@ -90,7 +248,7 @@ def clean_single_release_manifests(
 
     s3_client = glci.s3.s3_client(cicd_cfg=cicd_cfg)
 
-    def purge_if_outdated(release_manifest: glci.model.ReleaseManifest):
+    def purge_if_outdated(release_manifest: gm.ReleaseManifest):
         if release_manifest.build_ts_as_date() < oldest_allowed_date:
             # XXX also purge published images (if any)!
             if dry_run:
@@ -111,10 +269,10 @@ def clean_single_release_manifests(
 
 def _enumerate_objects_from_single_release_manifests(
     cicd_cfg=None,
-    prefix: str=glci.model.ReleaseManifest.manifest_key_prefix,
-) -> typing.Generator[glci.model.S3_ReleaseFile, None, None]:
+    prefix: str=gm.ReleaseManifest.manifest_key_prefix,
+) -> typing.Generator[gm.S3_ReleaseFile, None, None]:
     if not cicd_cfg:
-        cicd_cfg = glci.model.CicdCfg=glci.util.cicd_cfg()
+        cicd_cfg = gm.CicdCfg=glci.util.cicd_cfg()
 
     enumerate_releases = glci.util.preconfigured(
         glci.util.enumerate_releases,
@@ -126,10 +284,10 @@ def _enumerate_objects_from_single_release_manifests(
 
 def _enumerate_objects_from_release_manifest_sets(
     cicd_cfg=None,
-    prefix: str=glci.model.ReleaseManifestSet.release_manifest_set_prefix,
-) -> typing.Generator[glci.model.S3_ReleaseFile, None, None]:
+    prefix: str=gm.ReleaseManifestSet.release_manifest_set_prefix,
+) -> typing.Generator[gm.S3_ReleaseFile, None, None]:
     if not cicd_cfg:
-        cicd_cfg = glci.model.CicdCfg=glci.util.cicd_cfg()
+        cicd_cfg = gm.CicdCfg=glci.util.cicd_cfg()
 
     enumerate_release_sets = glci.util.preconfigured(
         glci.util.enumerate_release_sets,
@@ -149,7 +307,7 @@ def clean_orphaned_objects(
     dry_run: bool=False,
 ):
     if not cicd_cfg:
-        cicd_cfg = glci.model.CicdCfg=glci.util.cicd_cfg()
+        cicd_cfg = gm.CicdCfg=glci.util.cicd_cfg()
 
     all_objects = {
         object_descriptor for object_descriptor in

--- a/component_descriptor.py
+++ b/component_descriptor.py
@@ -9,6 +9,8 @@ import glci.util
 import ccc.aws
 import gci.componentmodel as cm
 
+import cnudie.retrieve
+
 logger = logging.getLogger(__name__)
 
 
@@ -104,6 +106,24 @@ def component_descriptor(
     )
 
     return component_descriptor
+
+
+def retrieve_component(
+        ctx_repository: str,
+        component_name: str,
+        component_version: str,
+):
+    lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
+        default_ctx_repo=cm.OciRepositoryContext(baseUrl=ctx_repository),
+    )
+
+    gardenlinux_component_descriptor = lookup(
+        cm.ComponentIdentity(
+            name=component_name,
+            version=component_version,
+        )
+    )
+    return gardenlinux_component_descriptor.component
 
 
 def virtual_machine_image_resource(

--- a/component_descriptor.py
+++ b/component_descriptor.py
@@ -108,24 +108,6 @@ def component_descriptor(
     return component_descriptor
 
 
-def retrieve_component(
-        ctx_repository: str,
-        component_name: str,
-        component_version: str,
-):
-    lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
-        default_ctx_repo=cm.OciRepositoryContext(baseUrl=ctx_repository),
-    )
-
-    gardenlinux_component_descriptor = lookup(
-        cm.ComponentIdentity(
-            name=component_name,
-            version=component_version,
-        )
-    )
-    return gardenlinux_component_descriptor.component
-
-
 def virtual_machine_image_resource(
     release_manifest: glci.model.OnlineReleaseManifest,
     version: str,

--- a/glci/alicloud.py
+++ b/glci/alicloud.py
@@ -269,7 +269,7 @@ class AlicloudImageMaker:
             if region_id == self.region:
                 continue
 
-            if self.regions_to_copy_to != None:
+            if self.regions_to_copy_to is not None:
                 if region_id in self.regions_to_copy_to:
                     region_ids.append(region_id)
             else:

--- a/glci/alicloud.py
+++ b/glci/alicloud.py
@@ -51,6 +51,7 @@ class AlicloudImageMaker:
         self.release = release
         self.bucket_name =  publishing_cfg.oss_bucket_name
         self.region = publishing_cfg.aliyun_region
+        self.regions_to_copy_to = publishing_cfg.copy_regions
         self.image_oss_key = f"gardenlinux-{self.release.version}.qcow2"
         self.image_name = f"gardenlinux-{self.release.canonical_release_manifest_key_suffix()}"
 
@@ -265,7 +266,13 @@ class AlicloudImageMaker:
 
         for region in response.get("Regions").get("Region"):
             region_id = region.get("RegionId")
-            if region_id != self.region:
+            if region_id == self.region:
+                continue
+
+            if self.regions_to_copy_to != None:
+                if region_id in self.regions_to_copy_to:
+                    region_ids.append(region_id)
+            else:
                 region_ids.append(region_id)
 
         return region_ids

--- a/glci/aws.py
+++ b/glci/aws.py
@@ -171,7 +171,7 @@ def enumerate_region_names(
 ):
     for region in ec2_client.describe_regions()['Regions']:
         region_name = region['RegionName']
-        if regions_to_include != None:
+        if regions_to_include is not None:
             if region_name in regions_to_include:
                 yield region_name
         else:
@@ -326,13 +326,12 @@ def _get_snapshots_for_image(
         Owners=["self"], Filters=[{"Name": "image-id", "Values": [image_id]}]
     )
 
-    if len(response["Images"]) > 0:
+    if (response["Images"]):
         image = response["Images"][0]
 
         for bdm in image.get("BlockDeviceMappings"):
             snapshots.append(bdm["Ebs"]["SnapshotId"])
-
-    if len(snapshots) < 1:
+    else:
         logger.warning(f"no snapshots found for {image_id=}")
     return snapshots
 

--- a/glci/aws.py
+++ b/glci/aws.py
@@ -161,18 +161,6 @@ def register_image(
         VirtualizationType='hvm' # | paravirtual
     )
 
-    ec2_client.create_tags(
-        Resources=[
-            result['ImageId'],
-        ],
-        Tags=[
-            {
-                'Key': 'sec-by-def-public-image-exception',
-                'Value': 'enabled',
-            },
-        ]
-    )
-
     # XXX need to wait until image is available (before publishing)
     return result['ImageId']
 
@@ -270,6 +258,7 @@ def copy_image(
             SourceImageId=ami_image_id,
             SourceRegion=src_region_name,
             Name=image_name,
+            CopyImageTags=True
         )
         # XXX: return (new) image-AMI
         response_ok(res)
@@ -429,6 +418,36 @@ def target_image_name_for_release(release: glci.model.OnlineReleaseManifest):
     return target_image_name
 
 
+def calculate_aws_tags(
+    image_tag_cfg: glci.model.ImageTagConfiguration,
+    release: glci.model.OnlineReleaseManifest,
+) -> list[dict[str, str]]:
+    tags = []
+    if not image_tag_cfg:
+        return tags
+    if image_tag_cfg.include_gardenlinux_version:
+        tags.append({"Key": "gardenlinux-version", "Value": release.version})
+    if image_tag_cfg.include_gardenlinux_committish:
+        tags.append({"Key": "gardenlinux-committish", "Value": release.build_committish})
+    for s in image_tag_cfg.static_tags:
+        tags.append({"Key": s, "Value": image_tag_cfg.static_tags[s]})
+    return tags
+
+
+def attach_tags(
+        ec2_client: 'botocore.client.EC2',
+        resources: list[str],
+        tags: list[dict[str, str]]
+):
+    if len(tags) == 0:
+        return
+    
+    _ = response_ok(ec2_client.create_tags(
+        Resources=resources,
+        Tags=tags
+    ))
+
+
 def upload_and_register_gardenlinux_image(
     aws_publishing_cfg: glci.model.PublishingTargetAWS,
     publishing_cfg: glci.model.PublishingCfg,
@@ -438,6 +457,7 @@ def upload_and_register_gardenlinux_image(
     for aws_cfg in aws_publishing_cfg.aws_cfgs:
         aws_cfg: glci.model.PublishingTargetAWSAccount
         aws_cfg_name = aws_cfg.aws_cfg_name
+        tags = calculate_aws_tags(aws_publishing_cfg.image_tags, release)
 
         logger.info(
             f'Running AWS-Publication for aws-config {aws_cfg_name}.'
@@ -486,6 +506,7 @@ def upload_and_register_gardenlinux_image(
             ec2_client=ec2_client,
             snapshot_task_id=snapshot_task_id,
         )
+        attach_tags(ec2_client=ec2_client, resources=[snapshot_id], tags=tags)
         logger.info(f'import task finished {snapshot_id=}')
 
         initial_ami_id = register_image(
@@ -494,6 +515,7 @@ def upload_and_register_gardenlinux_image(
             image_name=target_image_name,
             architecture=_to_aws_architecture(release.architecture),
         )
+        attach_tags(ec2_client=ec2_client, resources=[initial_ami_id], tags=tags)
         logger.info(f'registered {initial_ami_id=}')
 
         region_names = tuple(enumerate_region_names(ec2_client=ec2_client, regions_to_include=aws_cfg.copy_regions))

--- a/glci/aws.py
+++ b/glci/aws.py
@@ -354,7 +354,7 @@ def unregister_images_by_id(
     images: glci.model.AwsPublishedImageSet,
     dry_run: bool
 ):
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=len(images))
+    executor = concurrent.futures.ThreadPoolExecutor()
     results = []
 
     for image in images:

--- a/glci/aws.py
+++ b/glci/aws.py
@@ -179,9 +179,15 @@ def register_image(
 
 def enumerate_region_names(
     ec2_client: 'botocore.client.EC2',
+    regions_to_include: list[str] = None
 ):
     for region in ec2_client.describe_regions()['Regions']:
-        yield region['RegionName']
+        region_name = region['RegionName']
+        if regions_to_include != None:
+            if region_name in regions_to_include:
+                yield region_name
+        else:
+            yield region_name
 
 
 def wait_for_image_state(
@@ -420,7 +426,7 @@ def upload_and_register_gardenlinux_image(
         )
         logger.info(f'registered {initial_ami_id=}')
 
-        region_names = tuple(enumerate_region_names(ec2_client=ec2_client))
+        region_names = tuple(enumerate_region_names(ec2_client=ec2_client, regions_to_include=aws_cfg.copy_regions))
 
         try:
             image_map = dict(

--- a/glci/model.py
+++ b/glci/model.py
@@ -742,6 +742,7 @@ class PublishingTargetAWSAccount:
 @dataclasses.dataclass
 class PublishingTargetAWS:
     aws_cfgs: list[PublishingTargetAWSAccount]
+    image_tags: typing.Optional[ImageTagConfiguration]
     platform: Platform = 'aws' # should not overwrite
 
 
@@ -779,6 +780,13 @@ class PublishingTargetOpenstackBareMetal(PublishingTargetOpenstack):
 class OpenStackImageProperties:
     hypervisor_type: str
     openstack_properties: dict[str, str]
+
+@dataclasses.dataclass
+class ImageTagConfiguration:
+    include_gardenlinux_version: typing.Optional[bool]
+    include_gardenlinux_committish: typing.Optional[bool]
+    static_tags: typing.Optional[dict[str, str]]
+
 
 @dataclasses.dataclass
 class OcmCfg:

--- a/glci/model.py
+++ b/glci/model.py
@@ -783,6 +783,7 @@ class OpenStackImageProperties:
 @dataclasses.dataclass
 class OcmCfg:
     component_repository_cfg_name: str
+    overwrite_compnent_descriptor: typing.Optional[bool]
 
 @dataclasses.dataclass
 class S3_ManifestVersion:

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -74,6 +74,7 @@
       aws_cfg_name: 'gardenlinux-integration-test'
   ocm:
     component_repository_cfg_name: 'gardenlinux-test'
+    overwrite_component_descriptor: true
   targets:
     - platform: 'aws'
       aws_cfgs:

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -1,4 +1,9 @@
 - name: 'default'
+  manifest_s3_buckets:
+    - name: 'origin'
+      role: 'source'
+      bucket_name: 'gardenlinux-github-releases'
+      aws_cfg_name: 'gardenlinux'
   buildresult_s3_buckets:
     - name: 'origin'
       role: 'source'
@@ -52,3 +57,26 @@
         hypervisor_type: baremetal
         os_distro: debian10_64Guest
         img_config_drive: mandatory
+- name: 'gardener-integration-test'
+  manifest_s3_buckets:
+    - name: 'origin'
+      role: 'source'
+      bucket_name: 'gardenlinux-github-releases'
+      aws_cfg_name: 'gardenlinux-integration-test'
+    - name: 'tests'
+      role: 'target'
+      bucket_name: 'gardenlinux-test-import'
+      aws_cfg_name: 'gardenlinux-integration-test'
+  buildresult_s3_buckets:
+    - name: 'origin'
+      role: 'source'
+      bucket_name: 'gardenlinux-github-releases'
+      aws_cfg_name: 'gardenlinux-integration-test'
+  ocm:
+    component_repository_cfg_name: 'gardenlinux-test'
+  targets:
+    - platform: 'aws'
+      aws_cfgs:
+        - aws_cfg_name: 'gardenlinux-integration-test'
+          buildresult_bucket: 'origin'
+          copy_regions: ['eu-west-1']

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -27,6 +27,9 @@
           buildresult_bucket: 'origin'
         - aws_cfg_name: 'gardenlinux-cn'
           buildresult_bucket: 'replica-cn'
+      image_tags:
+        static_tags:
+          sec-by-def-public-image-exception: enabled
     - platform: 'gcp'
       gcp_cfg_name: 'gardenlinux'
       gcp_bucket_name: 'gardenlinux-images'
@@ -81,3 +84,10 @@
         - aws_cfg_name: 'gardenlinux-integration-test'
           buildresult_bucket: 'origin'
           copy_regions: ['eu-west-1']
+      image_tags:
+        include_gardenlinux_version: true
+        include_gardenlinux_committish: true
+        static_tags:
+          sec-by-def-public-image-exception: enabled
+          purpose: test
+          test-type: gardener-integration


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for a Gardener integration test pipeline that supports testing Garden Linux versions that have not been release (yet). The changes include a dedicated publishing config and several changes that allow for publishing temporary artefcats to non-productive locations.

Supports AWS only at the moment, the other platforms will follow in seperate PRs.

**Special notes for your reviewer**:

You might want to review the individual commits separately and have a look at their commit messages to understand their intentions.

This PR should not be squashed, the commits should be left intact upon merging.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The glci publishing gear now supports publishing and cleaning of temporary artefacts that can be used in Gardener integration tests.
```
