### PR TITLE
Add OpenStack support to the integration test pipeline code

### DIFF
--- a/glci/model.py
+++ b/glci/model.py
@@ -769,6 +769,7 @@ class PublishingTargetOpenstack:
     environment_cfg_name: str
     image_properties: typing.Optional[dict[str, str]]
     suffix: typing.Optional[str]
+    copy_regions: typing.Optional[list[str]]
     platform: Platform = 'openstack' # should not overwrite
 
 @dataclasses.dataclass

--- a/publish.py
+++ b/publish.py
@@ -238,22 +238,26 @@ def _publish_openstack_image(
     username = openstack_environments_cfg.credentials().username()
     password = openstack_environments_cfg.credentials().passwd()
 
-    openstack_env_cfgs = tuple((
-        gm.OpenstackEnvironment(
+    openstack_env_cfgs = []
+    for project in openstack_environments_cfg.projects():
+        if openstack_publishing_cfg and project.region() not in openstack_publishing_cfg.copy_regions:
+            continue
+
+        openstack_env_cfgs.append(gm.OpenstackEnvironment(
             project_name=project.name(),
             domain=project.domain(),
             region=project.region(),
             auth_url=project.auth_url(),
             username=username,
             password=password,
-        ) for project in openstack_environments_cfg.projects()
-    ))
+        )
+    )
 
     image_properties = openstack_publishing_cfg.image_properties
 
     return glci.openstack_image.upload_and_publish_image(
         s3_client,
-        openstack_environments_cfgs=openstack_env_cfgs,
+        openstack_environments_cfgs=tuple(openstack_env_cfgs),
         image_properties=image_properties,
         release=release,
         suffix=openstack_publishing_cfg.suffix

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -91,3 +91,14 @@
           sec-by-def-public-image-exception: enabled
           purpose: test
           test-type: gardener-integration
+    - platform: 'openstack'
+      environment_cfg_name: 'gardenlinux'
+      suffix: 'int-test'
+      copy_regions: ['eu-nl-1']
+      image_properties:
+        hypervisor_type: vmware
+        vmware_ostype: debian10_64Guest
+        hw_vif_model: vmxnet3
+        hw_disk_bus: scsi
+        vmware_adaptertype: paraVirtual
+        vmware_disktype: streamOptimized


### PR DESCRIPTION
**What this PR does / why we need it**:

PR #25 added supporting code to upload and remove Garden Linux artefacts to selected regions of Hyperscalers so they can be used in an integration tests pipeline for Gardener. This PR adds code and configuration to support OpenStack as well. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The glci publishing gear now supports publishing and cleaning of temporary artefacts in OpenStack so that they can be used in Gardener integration tests.
```
