### PR TITLE
Add OpenStack support to the integration test pipeline code

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -901,12 +901,8 @@ def publish_release_set():
     component_version = component_descriptor.component.version
 
     phase_logger.info('publishing component-descriptor')
-    phase_logger.info(f'{repository_context=} {component_name=} {component_version=}')
-
-    if cfg.ocm.overwrite_compnent_descriptor:
-        on_exist=cnudie.upload.UploadMode.OVERWRITE
-    else:
-        on_exist=cnudie.upload.UploadMode.SKIP
+    on_exist=cnudie.upload.UploadMode.OVERWRITE if cfg.ocm.overwrite_component_descriptor else cnudie.upload.UploadMode.SKIP
+    phase_logger.info(f'{repository_context=} {component_name=} {component_version=} {on_exist=}')
 
     cnudie.upload.upload_component_descriptor(
         component_descriptor=component_descriptor,

--- a/glci/model.py
+++ b/glci/model.py
@@ -792,7 +792,7 @@ class ImageTagConfiguration:
 @dataclasses.dataclass
 class OcmCfg:
     component_repository_cfg_name: str
-    overwrite_compnent_descriptor: typing.Optional[bool]
+    overwrite_component_descriptor: typing.Optional[bool]
 
 @dataclasses.dataclass
 class S3_ManifestVersion:

--- a/glci/model.py
+++ b/glci/model.py
@@ -769,6 +769,7 @@ class PublishingTargetOpenstack:
     environment_cfg_name: str
     image_properties: typing.Optional[dict[str, str]]
     suffix: typing.Optional[str]
+    copy_regions: typing.Optional[list[str]]
     platform: Platform = 'openstack' # should not overwrite
 
 @dataclasses.dataclass

--- a/publish.py
+++ b/publish.py
@@ -247,6 +247,8 @@ def _publish_openstack_image(
             username=username,
             password=password,
         ) for project in openstack_environments_cfg.projects()
+            if not openstack_publishing_cfg.copy_regions
+                or project.region() in openstack_publishing_cfg.copy_regions
     ))
 
     image_properties = openstack_publishing_cfg.image_properties

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -91,3 +91,14 @@
           sec-by-def-public-image-exception: enabled
           purpose: test
           test-type: gardener-integration
+    - platform: 'openstack'
+      environment_cfg_name: 'gardenlinux'
+      suffix: 'int-test'
+      copy_regions: ['eu-nl-1']
+      image_properties:
+        hypervisor_type: vmware
+        vmware_ostype: debian10_64Guest
+        hw_vif_model: vmxnet3
+        hw_disk_bus: scsi
+        vmware_adaptertype: paraVirtual
+        vmware_disktype: streamOptimized


### PR DESCRIPTION
**What this PR does / why we need it**:

PR #25 added supporting code to upload and remove Garden Linux artefacts to selected regions of Hyperscalers so they can be used in an integration tests pipeline for Gardener. This PR adds code and configuration to support OpenStack as well. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The glci publishing gear now supports publishing and cleaning of temporary artefacts in OpenStack so that they can be used in Gardener integration tests.
```
