### PR TITLE
publish ARM64 images to GCP

### DIFF
--- a/flavours.yaml
+++ b/flavours.yaml
@@ -17,5 +17,6 @@ flavour_sets:
         - arm64
         platforms:
         - aws
+        - gcp
         modifiers:
         - [ gardener, _prod ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Configures GLCI to also publish ARM64 images to GCP.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
ARM64 images of Garden Linux are now published to GCP.
```
