### PR TITLE
fix: fix obtaining ocm reference

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -972,10 +972,9 @@ def cleanup_release_set():
         raise RuntimeError(f"need to provide either --version or --version-file parameter")
 
     cfg = _publishing_cfg(parsed)
-    cfg_factory = ctx.cfg_factory()
 
     if not parsed.ocm_repo:
-        ocm_repo_base_url = cfg_factory.ctx_repository(cfg.ocm.ocm_repository)
+        ocm_repo_base_url = cfg.ocm.ocm_repository
     else:
         ocm_repo_base_url = parsed.ocm_repo
 

--- a/component_descriptor.py
+++ b/component_descriptor.py
@@ -53,7 +53,7 @@ def component_descriptor(
     release_manifests: list[glci.model.OnlineReleaseManifest],
     cfg_factory,
 ) -> cm.ComponentDescriptor:
-    ocm_repository = cfg_factory.ctx_repository(publishing_cfg.ocm.ocm_repository)
+    ocm_repository = publishing_cfg.ocm.ocm_repository
 
     s3_session = ccc.aws.session(publishing_cfg.origin_buildresult_bucket.aws_cfg_name)
     s3_client = s3_session.client('s3')


### PR DESCRIPTION
**What this PR does / why we need it**:

PR #31  introduced a little nit due to which ocm references could not be obtained. This PR fixes it.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
fix: fix obtaining ocm reference
```
