### PR TITLE
fix: do not pursue manifests with no keys

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -554,6 +554,8 @@ def ls_manifests():
             Bucket=cfg.origin_buildresult_bucket.bucket_name,
             Prefix=prefix,
         )
+        if matching_manifests['KeyCount'] == 0:
+            continue
         for entry in matching_manifests['Contents']:
             key = entry['Key']
             _, version, commit = key.rsplit('-', 2)
@@ -697,7 +699,6 @@ def publish_release_set():
             commit = input['committish']
 
     cfg = _publishing_cfg(parsed)
-    cfg_factory = ctx.cfg_factory()
 
     flavour_set = _flavourset(parsed)
 
@@ -890,7 +891,6 @@ def publish_release_set():
         commit=commit,
         publishing_cfg=cfg,
         release_manifests=release_manifests,
-        cfg_factory=cfg_factory,
     )
 
     if parsed.print_component_descriptor:

--- a/component_descriptor.py
+++ b/component_descriptor.py
@@ -50,8 +50,7 @@ def component_descriptor(
     version: str,
     commit: str,
     publishing_cfg: glci.model.PublishingCfg,
-    release_manifests: list[glci.model.OnlineReleaseManifest],
-    cfg_factory,
+    release_manifests: list[glci.model.OnlineReleaseManifest]
 ) -> cm.ComponentDescriptor:
     ocm_repository = publishing_cfg.ocm.ocm_repository
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug that occurs if an empty release manifest is found in S3. Also some code cleanup.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Fixed a bug that occurs if an empty release manifest is found in S3.
```
