### PR TITLE
remove update of job-image file

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -51,9 +51,6 @@ glci:
               image: europe-docker.pkg.dev/gardener-project/releases/cicd/glci-job-image
               dockerfile: 'Dockerfile'
               tag_as_latest: true
-        version:
-          versionfile: 'job-image-version'
-          preprocess: 'finalise'
         release:
           release_on_github: false
         component_descriptor:


### PR DESCRIPTION
**What this PR does / why we need it**:

With the removal of access for Gardener Robots to the github.com/gardenlinux org, it is no longer possible to update the `job-image-version` file from a Concourse pipeline, hence removing the relevant part in the `pipeline_definitions`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
