### PR TITLE
Support for Gardener integration tests on Azure

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -817,6 +817,8 @@ def publish_release_set():
                 )
             else:
                 raise ValueError(on_absent) # programming error
+        else:
+            publish.validate_publishing_configuration(manifest, cfg)
 
     phase_logger.info('publishing-cfg was found to be okay - starting publishing now')
 

--- a/glci/az.py
+++ b/glci/az.py
@@ -873,9 +873,10 @@ def delete_from_azure_community_gallery(
     for public_name in configured_gallery.sharing_profile.community_gallery_info.public_names:
         if public_name == image_community_gallery_name:
             image_gallery_is_configured_gallery = True
+            break
 
     if not image_gallery_is_configured_gallery:
-        raise RuntimeError(f"The community gallery of image {community_gallery_image_id} is not from the configured community gallery.")
+        raise RuntimeError(f"The community gallery of image {community_gallery_image_id} is not from the configured community gallery {shared_gallery_cfg.gallery_name}.")
 
     gallery_image_version = cclient.gallery_image_versions.get(
         resource_group_name=shared_gallery_cfg.resource_group_name,
@@ -938,3 +939,13 @@ def delete_from_azure_community_gallery(
             result = result.result()
     else:
         logger.warning(f"{image_definition=} still contains {image_version_count} image versions - keeping definition")
+
+
+def validate_azure_publishing_config(
+    release: glci.model.OnlineReleaseManifest,
+    publishing_cfg: glci.model.PublishingCfg,
+):
+    azure_publishing_cfg: glci.model.PublishingTargetAzure = publishing_cfg.target(platform=release.platform)
+
+    if azure_publishing_cfg.publish_to_marketplace and not azure_publishing_cfg.marketplace_cfg:
+        raise RuntimeError(f"Expected to publish to Azure Marketplace but no marketplace config in publishing config.")

--- a/glci/model.py
+++ b/glci/model.py
@@ -758,7 +758,8 @@ class PublishingTargetAzure:
     gallery_cfg_name: str
     storage_account_cfg_name: str
     service_principal_cfg_name: str
-    marketplace_cfg: AzureMarketplaceCfg
+    marketplace_cfg: typing.Optional[AzureMarketplaceCfg]
+    hyper_v_generations: typing.List[AzureHyperVGeneration]
     publish_to_marketplace: bool
     publish_to_community_galleries: bool
     platform: Platform = 'azure' # should not overwrite

--- a/publish.py
+++ b/publish.py
@@ -67,6 +67,31 @@ def publish_image(
         raise
 
 
+def validate_publishing_configuration(
+    release: gm.OnlineReleaseManifest,
+    cfg: gm.PublishingCfg
+):
+    if release.platform == 'azure':
+        validation_function = glci.az.validate_azure_publishing_config
+    elif release.platform == 'ali':
+        validation_function = None
+    elif release.platform == 'aws':
+        validation_function = None
+    elif release.platform == 'gcp':
+        validation_function = None
+    elif release.platform == 'openstack':
+        validation_function = None
+    elif release.platform == 'openstackbaremetal':
+        validation_function = None
+    elif release.platform == 'oci':
+        validation_function = None
+    else:
+        validation_function = None
+
+    if validation_function:
+        validation_function(release, cfg)
+
+
 def _publish_alicloud_image(
     release: gm.OnlineReleaseManifest,
     publishing_cfg: gm.PublishingCfg,

--- a/publish.py
+++ b/publish.py
@@ -161,8 +161,9 @@ def _publish_azure_image(
         storage_account_cfg=storage_account_cfg_serialized,
         shared_gallery_cfg=shared_gallery_cfg_serialized,
         marketplace_cfg=azure_publishing_cfg.marketplace_cfg,
+        hyper_v_generations=azure_publishing_cfg.hyper_v_generations,
         publish_to_community_gallery=azure_publishing_cfg.publish_to_community_galleries,
-        publish_to_marketplace=azure_publishing_cfg.publish_to_marketplace,
+        publish_to_marketplace=azure_publishing_cfg.publish_to_marketplace
     )
 
 

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -37,6 +37,7 @@
       gallery_cfg_name: 'gardenlinux-community-gallery'
       storage_account_cfg_name: 'gardenlinux-community-gallery'
       service_principal_cfg_name: 'gardenlinux'
+      hyper_v_generations: ['V1', 'V2']
       marketplace_cfg:
         offer_id: 'gardenlinux'
         publisher_id: 'sap'
@@ -102,3 +103,10 @@
         hw_disk_bus: scsi
         vmware_adaptertype: paraVirtual
         vmware_disktype: streamOptimized
+    - platform: 'azure'
+      service_principal_cfg_name: 'gardenlinux-integration-test'
+      storage_account_cfg_name: 'gardenlinux-integration-test'
+      gallery_cfg_name: 'gardenlinux-integration-test'
+      hyper_v_generations: ['V1']
+      publish_to_marketplace: false
+      publish_to_community_galleries: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds relevant code to glci to support Gardener integration tests on Azure. This includes:
- a dedicated publishing config to the Azure Garden Linux test subscription
- code to clean up images published to an Azure community image gallery
- the option to omit a Marketplace config in the publishing config if not Marketplace publishing is ever desired

**Special notes for your reviewer**:

Should be merged in to `main` **before** PR #30 is merged, PR #30 should be rebased then. Commits of this PR should be squashed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Support for Gardener integration test pipelines on Azure was added.
```
