### PR TITLE
Update concourse job-image to 0.2.0

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,7 +21,7 @@ glci:
           - '../ls-manifests'
           - '--print'
           - 'versions-and-commits'
-          image: europe-docker.pkg.dev/gardener-project/releases/cicd/glci-job-image:0.1.0
+          image: europe-docker.pkg.dev/gardener-project/releases/cicd/glci-job-image:0.2.0
     manual-release:
       repo:
         trigger: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the concourse job image to the latest 0.2.0 release.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
