### PR TITLE
Configure pipeline to work with `rel-1312` branch of gardenlinux/gardenlinux

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -14,7 +14,7 @@ glci:
       - name: 'GARDENLINUX'
         cfg_name: 'github_com'
         path: 'gardenlinux/gardenlinux'
-        branch: 'rel-934'
+        branch: 'rel-1312'
       steps:
         list-available-releases:
           execute:


### PR DESCRIPTION
**What this PR does / why we need it**:

Configures the Garden Linux release pipeline to use the `rel-1312` branch of https://github.com/gardenlinux/gardenlinux.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
