### PR TITLE
Disable publishing to Az Marketplace

### DIFF
--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -43,7 +43,7 @@
         publisher_id: 'sap'
         plan_id: 'greatest'
         notification_emails: ['thomas.buchner@sap.com','dirk.marwinski@sap.com','andre.russ@sap.com']
-      publish_to_marketplace: true
+      publish_to_marketplace: false
       publish_to_community_galleries: true
     - platform: 'openstack'
       environment_cfg_name: 'gardenlinux'


### PR DESCRIPTION
**What this PR does / why we need it**:

Garden Linux since version 1312 is published through Azure community image galleries rather than the Azure Marketplace and thus, publishing to Azure Marketplace gets disabled.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
publishing to Azure Marketplace is disabled
```
