### PR TITLE
Tag Garden Linux images with gVNIC driver on GCP

### DIFF
--- a/glci/gcp.py
+++ b/glci/gcp.py
@@ -84,6 +84,11 @@ def upload_image_from_gcp_store(
             'rawDisk': {
                 'source': image_blob.generate_signed_url(int(time.time())),
             },
+            'guestOsFeatures': [
+                {
+                    'type': 'GVNIC'
+                },
+            ],
         },
     )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Garden Linux images support the gVNIC network driver but the images are currently lacking the `"guestOsFeatures":[{"type":"GVNIC"}]` tag which prevents them to be used on generation 3 (and higher) GCE instance types.

This PR adds the missing tag to all images that will get published to GCP from now on.

**Fixes:**

Fixes #43 .

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Images published on GCP will be decorated with the `GVNIC` `guestOsFeatures` tag.
```
