### PR TITLE
Support for Gardener integration tests on GCP

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -39,7 +39,7 @@ def cleanup_image(
     elif release.platform == 'aws':
         cleanup_function = cleanup_aws_images_by_id
     elif release.platform == 'gcp':
-        cleanup_function = None # cleanup_gcp_images
+        cleanup_function = cleanup_gcp_images
     elif release.platform == 'azure':
         cleanup_function = cleanup_azure_community_gallery_images
     elif release.platform == 'openstack':
@@ -121,6 +121,7 @@ def clean_alicloud_images(
 def cleanup_gcp_images(
     release: gm.OnlineReleaseManifest,
     publishing_cfg: gm.PublishingCfg,
+    dry_run: bool = False
 ) -> gm.OnlineReleaseManifest:
     gcp_publishing_cfg: gm.PublishingTargetGCP = publishing_cfg.target(release.platform)
     cfg_factory = ci.util.ctx().cfg_factory()
@@ -134,6 +135,7 @@ def cleanup_gcp_images(
         gcp_project_name=gcp_cfg.project(),
         release=release,
         publishing_cfg=gcp_publishing_cfg,
+        dry_run=dry_run
     )
 
 

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -110,3 +110,6 @@
       hyper_v_generations: ['V1']
       publish_to_marketplace: false
       publish_to_community_galleries: true
+    - platform: 'gcp'
+      gcp_cfg_name: 'gardenlinux-integration-test'
+      gcp_bucket_name: 'gardenlinux-test-images'


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds code support Gardener integration tests on GCP,  similar to the changes in #38, #28 and #25.

This includes code to clean up images that were published on GCP based on their name and some minor changes to make the publishing process more resilient and the code a little more descriptive.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The glci publishing gear now supports publishing and cleaning of temporary artefacts in GCP so that they can be used in Gardener integration tests.
```
