### PR TITLE
Remove vSphere artefacts from component descriptor

### DIFF
--- a/flavours.yaml
+++ b/flavours.yaml
@@ -11,7 +11,6 @@ flavour_sets:
         - gcp
         - openstack
         - openstackbaremetal
-        - vmware
         modifiers:
         - [ gardener, _prod ]
       - architectures:


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes `vmware` from `flavours.yaml` so that vSphere artefacts are no longer included in Garden Linux' component descriptor.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Garden Linux artefacts for vSphere are no longer included in component descriptor.
```
