### PR TITLE
add GVNIC and VIRTIO_SCSI_MULTIQUEUE to GCP images

### DIFF
--- a/glci/gcp.py
+++ b/glci/gcp.py
@@ -104,7 +104,13 @@ def insert_image_to_gce_image_store(
             },
             'guestOsFeatures': [
                 {
-                    'type': 'GVNIC,VIRTIO_SCSI_MULTIQUEUE,UEFI_COMPATIBLE'
+                    'type_': 'VIRTIO_SCSI_MULTIQUEUE',
+                },
+                {
+                    'type_': 'UEFI_COMPATIBLE',
+                },
+                {
+                    'type_': 'GVNIC',
                 },
             ],
         },

--- a/glci/gcp.py
+++ b/glci/gcp.py
@@ -104,7 +104,7 @@ def insert_image_to_gce_image_store(
             },
             'guestOsFeatures': [
                 {
-                    'type': 'GVNIC'
+                    'type': 'GVNIC,VIRTIO_SCSI_MULTIQUEUE,UEFI_COMPATIBLE'
                 },
             ],
         },


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `GVNIC`, `UEFI_COMPATIBLE` and `VIRTIO_SCSI_MULTIQUEUE` guest_os_features to GCP images.

**Special notes for your reviewer**:

Only to be merged after https://github.com/gardenlinux/gardenlinux/pull/2022 got approved, merged and had one successful pipeline run.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Adds `GVNIC`, `UEFI_COMPATIBLE` and `VIRTIO_SCSI_MULTIQUEUE` guest_os_features to GCP images.
```
