### PR TITLE
fix: update glci-job-image to 0.2.0

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -40,7 +40,7 @@ glci:
           - '../run_publish_release_set.sh'
           - '--version-name'
           - 'default'
-          image: europe-docker.pkg.dev/gardener-project/releases/cicd/glci-job-image:0.1.0
+          image: europe-docker.pkg.dev/gardener-project/releases/cicd/glci-job-image:0.2.0
     update-job-image:
       repo:
         trigger: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Need to update glci-job-image to 0.2.0 so that `glci-rel-<major>` pipelines can be automatically created. 

Fixed in session by Thomas for rel-1424 branch: https://github.com/gardenlinux/glci/commit/fa67cdf71cd8be59b6500457e76e57d4c072d8d4
