### PR TITLE
fix: specifying guest os features on GCP

### DIFF
--- a/glci/gcp.py
+++ b/glci/gcp.py
@@ -104,13 +104,13 @@ def insert_image_to_gce_image_store(
             },
             'guestOsFeatures': [
                 {
-                    'type_': 'VIRTIO_SCSI_MULTIQUEUE',
+                    'type': 'VIRTIO_SCSI_MULTIQUEUE',
                 },
                 {
-                    'type_': 'UEFI_COMPATIBLE',
+                    'type': 'UEFI_COMPATIBLE',
                 },
                 {
-                    'type_': 'GVNIC',
+                    'type': 'GVNIC',
                 },
             ],
         },


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes submission of `guestOsFeatures` to GCP: for an `imges.insert()` request, if a raw body is supplied, the guestOsFeatures expect the key `type` (not `type_` as if an imageConfig got supplied instead like in the Garden Linux [platform tests](https://github.com/gardenlinux/gardenlinux/blob/5af58e67e6ff9097a417b1cbf9f4c655022ac70c/tests/integration/gcp.py#L406-L418))

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
specifying guest os features on GCP was fixed
```
