### PR TITLE
fix: skip experimental or local builds

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -559,6 +559,8 @@ def ls_manifests():
         for entry in matching_manifests['Contents']:
             key = entry['Key']
             _, version, commit = key.rsplit('-', 2)
+            if version == "experimental" or commit == "local":
+                continue
             epoch, _ = version.split('.')
             s = glci.model.S3_Manifest(
                 manifest_key=key,


### PR DESCRIPTION
**What this PR does / why we need it**:

When enumerating Garden Linux manifests, skip all occurrences of an _experimental_ or _local_ build.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
When enumerating Garden Linux manifests, skip all occurrences of an _experimental_ or _local_ build
```
