### PR TITLE
Switch AWS CN bucket and use checksums for replication

### DIFF
--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -11,7 +11,7 @@
       aws_cfg_name: 'gardenlinux'
     - name: 'replica-cn'
       role: 'replica'
-      bucket_name: 'gardenlinux'
+      bucket_name: 'gardenlinux-github-releases'
       aws_cfg_name: 'gardenlinux-cn'
       platforms: ['aws']
   ocm:


### PR DESCRIPTION
**What this PR does / why we need it**:

With https://github.com/gardenlinux/gardenlinux/pull/2134, the replication target for replication of build artefacts into AWS China changed to a different bucket. This change must be reflected in glci as well.

In addition: right now we only rely on artefact size and name to decide if replication to AWS China is necessary. With his PR, sha256 checksums will also be taken into account for artefacts that have them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Must be cherry-picked to relevant release branches (rel-1312 and rel-1443) as well.
