### PR TITLE
Enhance the upload process to Chinese OpenStack regions

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -792,10 +792,14 @@ def publish_release_set():
         run_sync = False
 
     if run_sync:
-        replicate.replicate_image_blobs(
+        replicas_present = replicate.check_replicated_image_blobs(
             publishing_cfg=cfg,
             release_manifests=release_manifests,
         )
+
+        if not replicas_present:
+            phase_logger.error(f"not all replicas are present - check the Garden Linux build and upload-to-S3 job")
+            exit(1)
     else:
         phase_logger.info('skipping sync-images (--skip-previous-phases)')
 

--- a/glci/model.py
+++ b/glci/model.py
@@ -773,7 +773,13 @@ class PublishingTargetOpenstack:
     image_properties: typing.Optional[dict[str, str]]
     suffix: typing.Optional[str]
     copy_regions: typing.Optional[list[str]]
+    cn_regions: typing.Optional[OpenstackChinaRegions]
     platform: Platform = 'openstack' # should not overwrite
+
+@dataclasses.dataclass
+class OpenstackChinaRegions:
+    region_names: typing.List[str]
+    buildresult_bucket: str
 
 @dataclasses.dataclass
 class PublishingTargetOpenstackBareMetal(PublishingTargetOpenstack):
@@ -861,7 +867,7 @@ class PublishingCfg:
         raise RuntimeError('did not find manifest-bucket w/ role `source`')
 
     @property
-    def target_manifest_buckets(self) -> typing.Tuple[BuildresultS3Bucket, None, None]:
+    def target_manifest_buckets(self) -> typing.Generator[BuildresultS3Bucket, None, None]:
         for bucket in self.manifest_s3_buckets:
             if bucket.role is ManifestBucketRole.TARGET:
                 yield bucket

--- a/glci/model.py
+++ b/glci/model.py
@@ -225,6 +225,8 @@ class ReleaseFile:
     '''
     name: str
     suffix: str
+    md5sum: typing.Optional[str]
+    sha256sum: typing.Optional[str]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -13,7 +13,7 @@
       role: 'replica'
       bucket_name: 'gardenlinux-github-releases'
       aws_cfg_name: 'gardenlinux-cn'
-      platforms: ['aws']
+      platforms: ['aws', 'openstack', 'openstackbaremetal']
   ocm:
     ocm_repository: europe-docker.pkg.dev/gardener-project/releases
   targets:
@@ -47,6 +47,10 @@
       publish_to_community_galleries: true
     - platform: 'openstack'
       environment_cfg_name: 'gardenlinux'
+      cn_regions:
+        region_names:
+        - ap-cn-1
+        buildresult_bucket: 'replica-cn'
       image_properties:
         hypervisor_type: vmware
         vmware_ostype: debian10_64Guest
@@ -56,6 +60,10 @@
         vmware_disktype: streamOptimized
     - platform: 'openstackbaremetal'
       environment_cfg_name: 'gardenlinux'
+      cn_regions:
+        region_names:
+        - ap-cn-1
+        buildresult_bucket: 'replica-cn'
       suffix: 'baremetal'
       image_properties:
         hypervisor_type: baremetal

--- a/replicate.py
+++ b/replicate.py
@@ -1,7 +1,5 @@
 import logging
-import tempfile
 import typing
-import os
 
 import binascii
 import base64
@@ -15,8 +13,6 @@ import ccc.aws
 import glci.model as gm
 import glci.util as gu
 
-from glci.aws import response_ok
-
 logger = logging.getLogger(__name__)
 
 
@@ -29,10 +25,9 @@ def check_blob_size_and_checksum(
         target_key: str
 ) -> bool:
     try:
-        checksum_not_available_default = 'checksum not available'
-
         # there were cases where replicated blobs were corrupt (typically, they had
         # length of zero octets); as a (weak) validation, at least compare sizes
+        # if sha256sums are available, we take those into account as well
         resp = target_client.head_object(
             Bucket=target_bucket,
             Key=target_key,
@@ -78,7 +73,7 @@ def check_blob_size_and_checksum(
             raise e
 
 
-def replicate_image_blobs(
+def check_replicated_image_blobs(
     publishing_cfg: gm.PublishingCfg,
     release_manifests: typing.Iterable[gm.ReleaseManifest],
 ):
@@ -88,8 +83,10 @@ def replicate_image_blobs(
     s3_source_session = ccc.aws.session(source_bucket.aws_cfg_name)
     s3_source_client = s3_source_session.client('s3')
 
+    all_replicates_exist = True
+
     for target_bucket in target_buckets:
-        logger.info(f'Performing image blob replication from {source_bucket.aws_cfg_name=} to {target_bucket.aws_cfg_name=}')
+        logger.info(f'Checking image blob replication from {source_bucket.aws_cfg_name=} to {target_bucket.aws_cfg_name=}')
         s3_target_session = ccc.aws.session(target_bucket.aws_cfg_name)
         s3_target_client = s3_target_session.client('s3')
 
@@ -101,93 +98,15 @@ def replicate_image_blobs(
             suffix = gu.vm_image_artefact_for_platform(platform=manifest.platform)
             image_blob_ref =  manifest.path_by_suffix(suffix=suffix)
 
-            if check_blob_size_and_checksum(s3_source_client,
+            logger.info(f"release artefact {image_blob_ref.s3_key}")
+            replicate_exists = check_blob_size_and_checksum(s3_source_client,
                                 source_bucket.bucket_name,
                                 image_blob_ref.s3_key,
                                 s3_target_client,
                                 target_bucket.bucket_name,
                                 image_blob_ref.s3_key
-            ) is not True:
-                logger.warning(f'will purge and re-replicate')
-                s3_target_client.delete_object(
-                    Bucket=target_bucket.bucket_name,
-                    Key=image_blob_ref.s3_key,
-                )
-            else:
-                logger.info(
-                    f'{image_blob_ref.s3_key} already existed in {target_bucket.bucket_name}'
-                )
-                continue
+            )
 
-            image_size = 0
-            try:
-                # XXX: we _might_ split stream to multiple targets; however, as of now there is only
-                # one single replication target, so skip this optimisation for now
-                resp = s3_source_client.get_object(
-                    Bucket=source_bucket.bucket_name,
-                    Key=image_blob_ref.s3_key,
-                )
-                image_size = resp['ContentLength']
-                body = resp['Body']
+            all_replicates_exist = all_replicates_exist and replicate_exists
 
-                logger.info(f'streaming to {target_bucket.bucket_name=} for {target_bucket.aws_cfg_name=}, {image_blob_ref.s3_key=}')
-                logger.info(f'.. this may take a couple of minutes ({image_size} octets)')
-                s3_target_client.upload_fileobj(
-                    Fileobj=body,
-                    Bucket=target_bucket.bucket_name,
-                    Key=image_blob_ref.s3_key,
-                    Config=bt.TransferConfig(
-                        use_threads=True,
-                        max_concurrency=5
-                    ),
-                )
-            except Exception as e:
-                logger.warning(f'there was an error trying to replicate using streaming: {e}')
-                logger.info('falling back to tempfile-backed replication')
-
-                with tempfile.TemporaryFile() as tf:
-                    s3_source_client.download_fileobj(
-                        Bucket=source_bucket.bucket_name,
-                        Key=image_blob_ref.s3_key,
-                        Fileobj=tf,
-                    )
-                    tempfile_size = tf.tell()
-
-                    if tempfile_size != image_size:
-                        raise RuntimeError(f"downloaded tempfile ({tempfile_size} octects) does not have the same size of the S3 image blob ({image_size} octects)")
-
-                    logger.info(f"downloaded to tempfile ({tempfile_size=})")
-                    tf.seek(0, os.SEEK_SET)
-
-                    s3_target_client.upload_fileobj(
-                        Fileobj=tf,
-                        Bucket=target_bucket.bucket_name,
-                        Key=image_blob_ref.s3_key,
-                        Config=bt.TransferConfig(
-                            use_threads=True,
-                            max_concurrency=5,
-                            num_download_attempts=20, # be very persistent before giving up
-                            # rationale: we sometimes see "sporadic"
-                            # connectivity issues when uploading through "great
-                            # chinese firewall"
-                        ),
-                    )
-
-            # check again that the transferred/replicated blob in the target has the same size as in the source, if this is not the case because of
-            # errors in above upload_fileobj(), vm-image-imports will fail with misleading errors
-            if check_blob_size_and_checksum(
-                s3_source_client,
-                source_bucket.bucket_name,
-                image_blob_ref.s3_key,
-                s3_target_client,
-                target_bucket.bucket_name,
-                image_blob_ref.s3_key
-            ) is not True:
-                raise RuntimeError(f"replicated blob sizes are not equal although replication operation did not yield any errors")
-
-            # make it world-readable (otherwise, vm-image-imports may fail)
-            response_ok(s3_target_client.put_object_acl(
-                ACL='public-read',
-                Bucket=target_bucket.bucket_name,
-                Key=image_blob_ref.s3_key,
-            ))
+    return all_replicates_exist


### PR DESCRIPTION
**What this PR does / why we need it**:

With https://github.com/gardenlinux/gardenlinux/pull/2134, Garden Linux build artefacts will be uploaded to an S3 bucket in AWS China as well. The replication step in glci is therefore no longer necessary and is thus reduced to a check if all required release artefacts are indeed available in S3 China.

To enhance the upload process to Chinese OpenStack regions, it is now possible to specify individual OpenStack regions for which release artefacts should not be taken from the main buildresult bucket but from a specified replication buildresult bucket.

This PR also enables glci to read release identifiers with checksums that were introduced in https://github.com/gardenlinux/gardenlinux/pull/2139.

**Special notes for your reviewer**:

Should be cherry-picked to `rel-1312` and `rel-1443` as the required replication step in the nightly action in gardenlinux/gardenlinux was cherry-picked as well ([ref](https://github.com/gardenlinux/gardenlinux/commit/d476bbfe6be8b963583218950b69f4b1f9546349) for `rel-1312` and [ref](https://github.com/gardenlinux/gardenlinux/commit/a36fd57a9bbeb6ff0070f306215f279b68bb4fe9) for `rel-1443`).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
To stabilise the upload process to Chinese OpenStack regions, it is now possible to specify individual OpenStack regions for which release artefacts should not be taken from the main buildresult bucket but from a specified replication buildresult bucket.
```
