### PR TITLE
Support to specify the regions in which a community gallery image should be published in Azure

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -251,6 +251,7 @@ def cleanup_azure_community_gallery_images(
         identifier_publisher=shared_gallery_cfg.identifier_publisher(),
         identifier_offer=shared_gallery_cfg.identifier_offer(),
         identifier_sku=shared_gallery_cfg.identifier_sku(),
+        regions=azure_publishing_cfg.gallery_regions,
     )
 
     published_gallery_images = release.published_image_metadata.published_gallery_images

--- a/glci/model.py
+++ b/glci/model.py
@@ -637,6 +637,7 @@ class AzureSharedGalleryCfg:
     identifier_publisher: str
     identifier_offer: str
     identifier_sku: str
+    regions: tuple[str]
 
 @dataclasses.dataclass(frozen=True)
 class OpenstackEnvironment:
@@ -764,6 +765,7 @@ class PublishingTargetAzure:
     hyper_v_generations: typing.List[AzureHyperVGeneration]
     publish_to_marketplace: bool
     publish_to_community_galleries: bool
+    gallery_regions: typing.Optional[list[str]]
     platform: Platform = 'azure' # should not overwrite
 
 

--- a/publish.py
+++ b/publish.py
@@ -177,6 +177,7 @@ def _publish_azure_image(
         identifier_publisher=shared_gallery_cfg.identifier_publisher(),
         identifier_offer=shared_gallery_cfg.identifier_offer(),
         identifier_sku=shared_gallery_cfg.identifier_sku(),
+        regions=azure_publishing_cfg.gallery_regions,
     )
 
     return glci.az.publish_azure_image(

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -118,6 +118,7 @@
       hyper_v_generations: ['V1']
       publish_to_marketplace: false
       publish_to_community_galleries: true
+      gallery_regions: ['northeurope']
     - platform: 'gcp'
       gcp_cfg_name: 'gardenlinux-integration-test'
       gcp_bucket_name: 'gardenlinux-test-images'


### PR DESCRIPTION
**What this PR does / why we need it**:

It is now possible to specify in `publishing-cfg.yaml` to which regions a community gallery image in Azure should be published.

By default - if left empty - all regions that are returned by Azures subscription client will be considered but for the Gardener integration test pipeline, it is required to specify the desired regions explicitly.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to specify in `publishing-cfg.yaml` to which regions a community gallery image in Azure should be published.
```
