### PR TITLE
fix branch config for rel-1312 pipeline

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -14,7 +14,7 @@ glci:
       - name: 'GARDENLINUX'
         cfg_name: 'github_com'
         path: 'gardenlinux/gardenlinux'
-        branch: 'rel-934'
+        branch: 'main'
       steps:
         list-available-releases:
           execute:
@@ -29,7 +29,7 @@ glci:
       - name: 'GARDENLINUX'
         cfg_name: 'github_com'
         path: 'gardenlinux/gardenlinux'
-        branch: 'main'
+        branch: 'rel-1312'
       - name: 'GARDENLINUX_BUILDER'
         cfg_name: 'github_com'
         path: 'gardenlinux/builder'


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the pipeline definition for the glci `rel-1312` branch to pull the `rel-1312` branch of gardenlinux/gardenlinux (instead of `main`).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
