### PR TITLE
Add OS Image features to Az images

### DIFF
--- a/glci/az.py
+++ b/glci/az.py
@@ -5,11 +5,9 @@ from datetime import (
 )
 from enum import Enum
 import logging
-import typing
 
 import requests
-from glci import util
-import version
+
 from msal import ConfidentialClientApplication
 from azure.storage.blob import (
     BlobClient,
@@ -31,6 +29,7 @@ from azure.mgmt.compute.models import (
     CommunityGalleryImageVersion,
     GalleryArtifactVersionSource,
     GalleryImage,
+    GalleryImageFeature,
     GalleryImageIdentifier,
     GalleryImageVersion,
     GalleryImageVersionPublishingProfile,
@@ -536,6 +535,10 @@ def _create_shared_image(
             description=shared_gallery_cfg.description,
             eula=shared_gallery_cfg.eula,
             release_note_uri=shared_gallery_cfg.release_note_uri,
+            features=[
+                GalleryImageFeature(name="IsAcceleratedNetworkSupported", value="True"),
+                GalleryImageFeature(name="DiskControllerTypes", value="SCSI, NVMe"),
+            ],
             os_type=OperatingSystemTypes.LINUX,
             os_state=OperatingSystemStateTypes.GENERALIZED,
             hyper_v_generation=HyperVGeneration(hyper_v_generation.value),

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -34,7 +34,7 @@
       gcp_cfg_name: 'gardenlinux'
       gcp_bucket_name: 'gardenlinux-images'
     - platform: 'azure'
-      gallery_cfg_name: 'gardenlinux-community-gallery'
+      gallery_cfg_name: 'gardenlinux-community-gallery-nvme'
       storage_account_cfg_name: 'gardenlinux-community-gallery'
       service_principal_cfg_name: 'gardenlinux'
       hyper_v_generations: ['V1', 'V2']
@@ -115,10 +115,10 @@
       service_principal_cfg_name: 'gardenlinux-integration-test'
       storage_account_cfg_name: 'gardenlinux-integration-test'
       gallery_cfg_name: 'gardenlinux-integration-test'
-      hyper_v_generations: ['V1']
+      hyper_v_generations: ['V1', 'V2']
       publish_to_marketplace: false
       publish_to_community_galleries: true
-      gallery_regions: ['northeurope']
+      gallery_regions: ['northeurope', 'westeurope']
     - platform: 'gcp'
       gcp_cfg_name: 'gardenlinux-integration-test'
       gcp_bucket_name: 'gardenlinux-test-images'


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the following image features to images published to Azure to support latest machine types with Garden Linux:

`IsAcceleratedNetworkSupported: True`
`DiskControllerTypes: "SCSI, NVMe"`

**Which issue(s) this PR fixes**:
Fixes #58

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NVMe and Accelerated Features are added to Garden Linux images on Azure
```
