### PR TITLE
remove ap-south-1 from regions in ali cloud

### DIFF
--- a/glci/alicloud.py
+++ b/glci/alicloud.py
@@ -275,6 +275,9 @@ class AlicloudImageMaker:
             else:
                 region_ids.append(region_id)
 
+        # https://www.alibabacloud.com/help/en/cloud-migration-guide-for-beginners/latest/regions-and-zones
+        # As of 2024-08-12: 'India (Mumbai) Closing Down (ap-south-1)'
+        region_ids.remove('ap-south-1')
         return region_ids
 
     ####


### PR DESCRIPTION
As of 2024-08-12: 'India (Mumbai) Closing Down
https://www.alibabacloud.com/help/en/cloud-migration-guide-for-beginners/latest/regions-and-zones
