### PR TITLE
fix ocm call for component-descriptor generation

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -904,13 +904,13 @@ def publish_release_set():
     if parsed.print_component_descriptor:
         pprint.pprint(component_descriptor)
 
-    repository_context = component_descriptor.component.current_repository_ctx().baseUrl
+    oci_ref = component_descriptor.component.current_ocm_repo.oci_ref
     component_name = component_descriptor.component.name
     component_version = component_descriptor.component.version
 
     phase_logger.info('publishing component-descriptor')
     on_exist=cnudie.upload.UploadMode.OVERWRITE if cfg.ocm.overwrite_component_descriptor else cnudie.upload.UploadMode.SKIP
-    phase_logger.info(f'{repository_context=} {component_name=} {component_version=} {on_exist=}')
+    phase_logger.info(f'{oci_ref=} {component_name=} {component_version=} {on_exist=}')
 
     cnudie.upload.upload_component_descriptor(
         component_descriptor=component_descriptor,

--- a/glci/gcp.py
+++ b/glci/gcp.py
@@ -239,6 +239,7 @@ def upload_and_publish_image(
                 compute_client=compute_client,
                 gcp_project_name=gcp_project_name,
                 release=release,
+                dry_run=False
             )
             release_manifest = insert_image_to_gce_image_store(
                 compute_client=compute_client,


### PR DESCRIPTION
**What this PR does / why we need it**:

`gci.compomentmodel` was deprecated in [gardener-cc-utils](https://github.com/gardener/cc-utils), replacing all calls to it with respective calls to [ocm](https://github.com/gardener/cc-utils/blob/master/ocm/__init__.py)

Also fixing a missing parameter to the cleanup functions for GCP.
