### PR TITLE
Enable IMDSv2 by default for our images.

### DIFF
--- a/glci/aws.py
+++ b/glci/aws.py
@@ -145,6 +145,7 @@ def register_image(
     result = ec2_client.register_image(
         # ImageLocation=XX, s3-url?
         Architecture=architecture,
+        ImdsSupport='v2.0', # Ensure we're using the hardened IMDS version
         BlockDeviceMappings=[
             {
                 'DeviceName': root_device_name,


### PR DESCRIPTION
This enables using the Image Metadata Server v2 during the AMI publishing process. This way all published images *should* utilize the IMDSv2.

