### PR TITLE
fix: skip enumerating `today` builds when enumerating versions with `ls-manifests`

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -559,7 +559,7 @@ def ls_manifests():
         for entry in matching_manifests['Contents']:
             key = entry['Key']
             _, version, commit = key.rsplit('-', 2)
-            if version == "experimental" or commit == "local":
+            if version in ["experimental", "today"] or commit == "local":
                 continue
             epoch, _ = version.split('.')
             s = glci.model.S3_Manifest(


### PR DESCRIPTION
**What this PR does / why we need it**:

When `today` builds are in the build result S3 buckets, glci will fail to enumerate available versions in that bucket with:

```
Traceback (most recent call last):
  File "./ls-manifests", line 1110, in <module>
    main()
  File "./ls-manifests", line 1106, in main
    func()
  File "./ls-manifests", line 565, in ls_manifests
    epoch, _ = version.split('.')
    ^^^^^^^^
ValueError: not enough values to unpack (expected 2, got 1)
```

This PR makes glci skip over `today` builds.
