### PR TITLE
do not attempt to set_object_acl for a bucket without ACLs when publishing on AWS

### DIFF
--- a/glci/aws.py
+++ b/glci/aws.py
@@ -454,6 +454,20 @@ def attach_tags(
     ))
 
 
+def is_bucket_acl_enabled(
+    s3_client: 'botocore.client.S3',
+    bucket_name: str
+) -> bool:
+    bucket_acl = response_ok(s3_client.get_bucket_acl(Bucket=bucket_name))
+    owner_id = bucket_acl['Owner'].get('ID', None)
+    for grant in bucket_acl['Grants']:
+        if (grant['Grantee']['Type'] == "CanonicalUser" and
+            grant['Grantee'].get('ID', "") == owner_id and 
+            grant['Permission'] == "FULL_CONTROL"):
+            return False
+    return True
+
+
 def upload_and_register_gardenlinux_image(
     aws_publishing_cfg: glci.model.PublishingTargetAWS,
     publishing_cfg: glci.model.PublishingCfg,
@@ -485,11 +499,12 @@ def upload_and_register_gardenlinux_image(
         # make blob public prior to importing (snapshot-import will otherwise break, e.g. if
         # bucket is not entirely configured to be public)
         try:
-            s3_client.put_object_acl(
-                ACL='public-read',
-                Bucket=bucket_name,
-                Key=raw_image_key,
-            )
+            if is_bucket_acl_enabled(s3_client=s3_client, bucket_name=bucket_name):
+                s3_client.put_object_acl(
+                    ACL='public-read',
+                    Bucket=bucket_name,
+                    Key=raw_image_key,
+                )
         except:
             logger.warning('failed to set s3-blob to public - snapshot-import might fail')
             traceback.print_exc()


### PR DESCRIPTION
**What this PR does / why we need it**:

When publishing Garden Linux images to AWS, the code attempts to `put_object_acl` on the image blob in the buildresult bucket. If that bucket has ACLs disabled, it will print a the following warning:

```
2024-11-19 23:06:30,328 [WARNING] glci.aws: failed to set s3-blob to public - snapshot-import might fail
Traceback (most recent call last):
  File "/tmp/build/49900f65/git-gardenlinux.glci-rel-1592/glci/aws.py", line 488, in upload_and_register_gardenlinux_image
    s3_client.put_object_acl(
  File "/usr/lib/python3.11/site-packages/botocore/client.py", line 535, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/botocore/client.py", line 980, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (AccessControlListNotSupported) when calling the PutObjectAcl operation: The bucket does not allow ACLs
```

Even though just a warning, this output is confusing. This PR introduces a check if the bucket in question supports ACLs and will not issue the `put_object_acl` call if ACLs are not supported.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Unnecessary warnings about failing `put_object_acl` calls are suppressed for buckets that do not support ACLs.
```
