### PR TITLE
Allow specify a custom image visibility for OpenStack

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -44,6 +44,8 @@ def cleanup_image(
         cleanup_function = cleanup_azure_community_gallery_images
     elif release.platform == 'openstack':
         cleanup_function = cleanup_openstack_images_by_id
+    elif release.platform == 'openstackbaremetal':
+        cleanup_function = cleanup_openstack_images_by_id
     elif release.platform == 'oci':
         cleanup_function = None
     else:

--- a/glci/model.py
+++ b/glci/model.py
@@ -813,6 +813,7 @@ class PublishingTargetOpenstack:
     suffix: typing.Optional[str]
     copy_regions: typing.Optional[list[str]]
     cn_regions: typing.Optional[OpenstackChinaRegions]
+    visibility: str
     platform: Platform = 'openstack' # should not overwrite
 
 @dataclasses.dataclass

--- a/glci/model.py
+++ b/glci/model.py
@@ -805,6 +805,11 @@ class PublishingTargetAzure:
     gallery_regions: typing.Optional[list[str]]
     platform: Platform = 'azure' # should not overwrite
 
+class OpenStackVisibility(enum.StrEnum):
+    public = 'public'
+    community = 'community'
+    private = 'private'
+
 
 @dataclasses.dataclass
 class PublishingTargetOpenstack:
@@ -813,7 +818,7 @@ class PublishingTargetOpenstack:
     suffix: typing.Optional[str]
     copy_regions: typing.Optional[list[str]]
     cn_regions: typing.Optional[OpenstackChinaRegions]
-    visibility: str
+    visibility: OpenStackVisibility
     platform: Platform = 'openstack' # should not overwrite
 
 @dataclasses.dataclass

--- a/glci/openstack_image.py
+++ b/glci/openstack_image.py
@@ -31,7 +31,7 @@ class OpenstackImageUploader:
             project_domain_name=self.openstack_env.domain,
         )
 
-    def upload_image_from_fs(self, name: str, path: str, meta: dict, timeout_seconds=86400):
+    def upload_image_from_fs(self, name: str, path: str, meta: dict, visibility: glci.model.OpenStackVisibility, timeout_seconds=86400):
         '''Upload an image from filesystem to Openstack Glance.'''
 
         conn = self._get_connection()
@@ -40,7 +40,7 @@ class OpenstackImageUploader:
             filename=path,
             disk_format='vmdk',
             container_format='bare',
-            visibility='community',
+            visibility=visibility,
             timeout=timeout_seconds,
             **meta,
         )
@@ -60,7 +60,7 @@ class OpenstackImageUploader:
                 conn.image.delete_image(image=image)
                 logger.info(f"deleted image with {image.id=} in {region=}")
 
-    def upload_image_from_url(self, name: str, url :str, meta: dict, visibility: str, timeout_seconds=86400):
+    def upload_image_from_url(self, name: str, url :str, meta: dict, visibility: glci.model.OpenStackVisibility, timeout_seconds=86400):
         '''Import an image from web url to Openstack Glance.'''
 
         logger.info(
@@ -115,7 +115,7 @@ def upload_and_publish_image(
     image_properties: dict,
     release: glci.model.OnlineReleaseManifest,
     suffix: str = None,
-    visibility: str = 'community'
+    visibility: glci.model.OpenStackVisibility = glci.model.OpenStackVisibility.community
 ) -> glci.model.OnlineReleaseManifest:
     """Import an image from S3 into OpenStack Glance."""
 

--- a/glci/openstack_image.py
+++ b/glci/openstack_image.py
@@ -60,7 +60,7 @@ class OpenstackImageUploader:
                 conn.image.delete_image(image=image)
                 logger.info(f"deleted image with {image.id=} in {region=}")
 
-    def upload_image_from_url(self, name: str, url :str, meta: dict, timeout_seconds=86400):
+    def upload_image_from_url(self, name: str, url :str, meta: dict, visibility: str, timeout_seconds=86400):
         '''Import an image from web url to Openstack Glance.'''
 
         logger.info(
@@ -74,7 +74,7 @@ class OpenstackImageUploader:
             name=name,
             disk_format='vmdk',
             container_format='bare',
-            visibility='community',
+            visibility=visibility,
             timeout=timeout_seconds,
             **meta,
         )
@@ -115,6 +115,7 @@ def upload_and_publish_image(
     image_properties: dict,
     release: glci.model.OnlineReleaseManifest,
     suffix: str = None,
+    visibility: str = 'community'
 ) -> glci.model.OnlineReleaseManifest:
     """Import an image from S3 into OpenStack Glance."""
 
@@ -145,7 +146,7 @@ def upload_and_publish_image(
         )
 
         uploader = OpenstackImageUploader(env_cfg)
-        image_id = uploader.upload_image_from_url(image_name, s3_image_url, image_meta)
+        image_id = uploader.upload_image_from_url(name=image_name, url=s3_image_url, meta=image_meta, visibility=visibility)
         uploader.wait_image_ready(image_id)
 
         published_images.append(glci.model.OpenstackPublishedImage(

--- a/publish.py
+++ b/publish.py
@@ -310,5 +310,6 @@ def _publish_openstack_image(
         openstack_environments_cfgs=openstack_env_cfgs,
         image_properties=image_properties,
         release=release,
-        suffix=openstack_publishing_cfg.suffix
+        suffix=openstack_publishing_cfg.suffix,
+        visibility=openstack_publishing_cfg.visibility
     )

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -61,6 +61,7 @@
         region_names:
         - ap-cn-1
         buildresult_bucket: 'replica-cn'
+      visibility: 'community'
       image_properties:
         hypervisor_type: vmware
         vmware_ostype: debian10_64Guest
@@ -75,6 +76,7 @@
         - ap-cn-1
         buildresult_bucket: 'replica-cn'
       suffix: 'baremetal'
+      visibility: 'public'
       image_properties:
         hypervisor_type: baremetal
         os_distro: debian10_64Guest
@@ -114,6 +116,7 @@
       environment_cfg_name: 'gardenlinux'
       suffix: 'int-test'
       copy_regions: ['eu-nl-1']
+      visibility: 'community'
       image_properties:
         hypervisor_type: vmware
         vmware_ostype: debian10_64Guest

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -61,7 +61,7 @@
         region_names:
         - ap-cn-1
         buildresult_bucket: 'replica-cn'
-      visibility: 'community'
+      visibility: community
       image_properties:
         hypervisor_type: vmware
         vmware_ostype: debian10_64Guest
@@ -76,7 +76,7 @@
         - ap-cn-1
         buildresult_bucket: 'replica-cn'
       suffix: 'baremetal'
-      visibility: 'public'
+      visibility: public
       image_properties:
         hypervisor_type: baremetal
         os_distro: debian10_64Guest
@@ -116,7 +116,7 @@
       environment_cfg_name: 'gardenlinux'
       suffix: 'int-test'
       copy_regions: ['eu-nl-1']
-      visibility: 'community'
+      visibility: community
       image_properties:
         hypervisor_type: vmware
         vmware_ostype: debian10_64Guest


### PR DESCRIPTION
**What this PR does / why we need it**:

Certain image families in OpenStack must be published with `community` visibility while others must be published with `public` visibility. 

This PR enables GLCI to specify the visibility with which images should be published in the publishing config and sets OpenStack baremetal images to `public`.

**Which issue(s) this PR fixes**:
Fixes #117

**Special notes for your reviewer**:

Please test these changes before merging!
Must be cherry-picked to `rel-1443` and `rel-1592`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Image visibility for images in OpenStack glance can 
```
