### PR TITLE
publish AWS images with boot-mode `uefi-preffered`

### DIFF
--- a/glci/aws.py
+++ b/glci/aws.py
@@ -149,6 +149,7 @@ def register_image(
         BlockDeviceMappings=[
             {
                 'DeviceName': root_device_name,
+                'BootMode': 'uefi-preferred',
                 'Ebs': {
                     'DeleteOnTermination': True,
                     'SnapshotId': snapshot_id,


### PR DESCRIPTION
**What this PR does / why we need it**:

Garden Linux images support booting from UEFI for a very long time. To make them boot with UEFI on supported EC2 machine types (and fall back to legacy BIOS for those machine types that do not support UEFI), images get registered with the `BootMode=uefi-preferred` flag.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Garden Linux images are published with boot-mode `uefi-preffered` on AWS 
```
