### PR TITLE
Bootstrap devcontainer config to work with glci

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/python:3.11-bookworm
 
-RUN apt-get update -q && apt-get install -yq build-essential
+RUN apt-get update -q && apt-get install -yq build-essential git
+RUN pip install certifi

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/python:3.11-bookworm
+
+RUN apt-get update -q && apt-get install -yq build-essential

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+    "name": "glci",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "pipenv install --system"
+
+    // Configure tool-specific properties.
+    // "customizations": {},
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,19 +5,15 @@
     "build": {
         "dockerfile": "Dockerfile"
     },
-
     // Features to add to the dev container. More info: https://containers.dev/features.
     // "features": {},
-
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
-
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "pipenv install --system"
-
+    "postCreateCommand": "pipenv install --system && git clone https://github.com/gardenlinux/gardenlinux ../gardenlinux && git clone https://github.com/gardenlinux/builder ../gardenlinux-builder",
     // Configure tool-specific properties.
     // "customizations": {},
-
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-    // "remoteUser": "root"
+    // fixme(fwilhe): not sure if we need that, but with non-root we can't clone into /workspaces
+    "remoteUser": "root"
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     reviewers:
       - "gardenlinux/garden-linux-maintainers"
       - "gardenlinux/glci-maintainers"
+
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/github_release.py
+++ b/github_release.py
@@ -2,7 +2,7 @@ import os
 
 from string import Template
 
-import gci.componentmodel as cm
+import ocm
 
 import ctx
 import glci.model
@@ -225,10 +225,10 @@ def make_release(
     ctx_repo_base_url = cfg.base_url()
 
     lookup = cnudie.retrieve.create_default_component_descriptor_lookup(
-        default_ctx_repo=cm.OciRepositoryContext(base_url=ctx_repo_base_url)
+        default_ctx_repo=ocm.OciRepositoryContext(base_url=ctx_repo_base_url)
     )
 
-    comp_descr = lookup(cm.ComponentIdentity(
+    comp_descr = lookup(ocm.ComponentIdentity(
         name='github.com/gardenlinux/gardenlinux',
         version=version,
 


### PR DESCRIPTION
Create a [devcontainer](https://containers.dev) config to work with glci.
The purpose is to make share a usable configuration and remove friction for people who contribute to glci.