### PR TITLE
Set the NVMe-supported flag for AliCloud images

### DIFF
--- a/glci/alicloud.py
+++ b/glci/alicloud.py
@@ -8,12 +8,14 @@ import time
 
 import aliyunsdkcore.client
 from aliyunsdkcore.client import AcsClient
-from aliyunsdkecs.request.v20140526 import CopyImageRequest
-from aliyunsdkecs.request.v20140526 import DeleteImageRequest
-from aliyunsdkecs.request.v20140526 import DescribeImagesRequest
-from aliyunsdkecs.request.v20140526 import DescribeRegionsRequest
-from aliyunsdkecs.request.v20140526 import ImportImageRequest
-from aliyunsdkecs.request.v20140526 import ModifyImageSharePermissionRequest
+from aliyunsdkecs.request.v20140526 import (
+    CopyImageRequest,
+    DeleteImageRequest,
+    DescribeImagesRequest,
+    DescribeRegionsRequest,
+    ImportImageRequest,
+    ModifyImageSharePermissionRequest
+)
 import oss2
 
 import glci.model
@@ -199,6 +201,12 @@ class AlicloudImageMaker:
                 "OSSObject": self.image_oss_key,
             }]
             req.set_DiskDeviceMappings(devMap)
+            
+            featureMap = {
+                "NvmeSupport": "supported"
+            }
+            req.set_Features(featureMap)
+
             logger.info(f"dev: {devMap}")
             response = parse_response(
                 self.acs_client.do_action_with_exception(req))


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets the `NvmeSupport` flag for AliCloud images during image import so that they can be used with NVMe only machine types such as `ecs.g8ae.large`.

**Which issue(s) this PR fixes**:
Fixes #49 

**Special notes for your reviewer**:

May need to be cherry-picked to `rel-1443` and `rel-1592` branches.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
AliCloud images are now imported with the `NvmeSupport` flag.
```
