### PR TITLE
Add support for multiple flavoursets

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 # the version defined in this file specifies the _next_ release version of gardenlinux, as well as
 # (implicitly) the gardenlinux epoch (days since 2020-04-01) to use as dependency timestamp.
 # use `today` to build against latest
-934.1
+today

--- a/retrieve-single-manifest
+++ b/retrieve-single-manifest
@@ -1,1 +1,0 @@
-.cicd-cli.py


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow support for multiple flavoursets. If more than one is specified, GLCI will publish or cleanup all of them under the same component descriptor.
This changes the parameter `--flavourset-name` to `--flavourset`. It allows multiple of them. If none are specified, all flavoursets present in the flavoursets file are used. By default, this file contains just 1 flavourset called `gardener` which preserves the behavior under the previous default flavourset (which was hardcoded to `gardener`).

**Which issue(s) this PR fixes**:
Fixes #163 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add support for multiple flavoursets
```
