### PR TITLE
Remove code used to publish to Azure Marketplace

### DIFF
--- a/glci/model.py
+++ b/glci/model.py
@@ -131,7 +131,7 @@ class FeatureDescriptor:
             yield included_feature
 
 
-class Architecture(enum.Enum):
+class Architecture(enum.StrEnum):
     """
     gardenlinux' target architectures, following Debian's naming
     """
@@ -630,14 +630,6 @@ class PackageBuildCfg:
 
 
 @dataclasses.dataclass(frozen=True)
-class AzureMarketplaceCfg:
-    offer_id: str
-    publisher_id: str
-    plan_id: str
-    notification_emails: list[str]
-
-
-@dataclasses.dataclass(frozen=True)
 class AzureServicePrincipalCfg:
     tenant_id: str
     client_id: str
@@ -803,10 +795,7 @@ class PublishingTargetAzure:
     gallery_cfg_name: str
     storage_account_cfg_name: str
     service_principal_cfg_name: str
-    marketplace_cfg: typing.Optional[AzureMarketplaceCfg]
     hyper_v_generations: typing.List[AzureHyperVGeneration]
-    publish_to_marketplace: bool
-    publish_to_community_galleries: bool
     gallery_regions: typing.Optional[list[str]]
     platform: Platform = 'azure' # should not overwrite
 

--- a/publish.py
+++ b/publish.py
@@ -70,7 +70,7 @@ def validate_publishing_configuration(
     cfg: gm.PublishingCfg
 ):
     if release.platform == 'azure':
-        validation_function = glci.az.validate_azure_publishing_config
+        validation_function = None
     elif release.platform == 'ali':
         validation_function = None
     elif release.platform == 'aws':
@@ -138,10 +138,6 @@ def _publish_azure_image(
     for azure_publishing_cfg in azure_publishing_cfgs:
         logger.info(f"targetting {azure_publishing_cfg.cloud}")
 
-        if azure_publishing_cfg.cloud == gm.AzureCloud.CHINA and azure_publishing_cfg.publish_to_marketplace:
-            logger.warning("Publishing to Azure Marketplace in Azure China is not supported, disabling it")
-            azure_publishing_cfg.publish_to_marketplace = False
-
         aws_session = glci.aws.session(
             publishing_cfg.buildresult_bucket(azure_publishing_cfg.buildresult_bucket).aws_cfg_name
                 if azure_publishing_cfg.buildresult_bucket
@@ -194,11 +190,8 @@ def _publish_azure_image(
             service_principal_cfg=azure_principal_serialized,
             storage_account_cfg=storage_account_cfg_serialized,
             shared_gallery_cfg=shared_gallery_cfg_serialized,
-            marketplace_cfg=azure_publishing_cfg.marketplace_cfg,
             hyper_v_generations=azure_publishing_cfg.hyper_v_generations,
             azure_cloud=azure_publishing_cfg.cloud,
-            publish_to_community_gallery=azure_publishing_cfg.publish_to_community_galleries,
-            publish_to_marketplace=azure_publishing_cfg.publish_to_marketplace
         )
 
     return release

--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -39,13 +39,6 @@
       storage_account_cfg_name: 'gardenlinux-community-gallery'
       service_principal_cfg_name: 'gardenlinux'
       hyper_v_generations: ['V1', 'V2']
-      marketplace_cfg:
-        offer_id: 'gardenlinux'
-        publisher_id: 'sap'
-        plan_id: 'greatest'
-        notification_emails: ['thomas.buchner@sap.com','dirk.marwinski@sap.com','andre.russ@sap.com']
-      publish_to_marketplace: false
-      publish_to_community_galleries: true
     - platform: 'azure'
       cloud: 'china'
       buildresult_bucket: 'replica-cn'
@@ -53,8 +46,6 @@
       storage_account_cfg_name: 'gardenlinux-community-gallery-cn'
       service_principal_cfg_name: 'gardenlinux-cn'
       hyper_v_generations: ['V1', 'V2']
-      publish_to_marketplace: false
-      publish_to_community_galleries: true
     - platform: 'openstack'
       environment_cfg_name: 'gardenlinux'
       cn_regions:
@@ -130,8 +121,6 @@
       storage_account_cfg_name: 'gardenlinux-integration-test'
       gallery_cfg_name: 'gardenlinux-integration-test'
       hyper_v_generations: ['V1', 'V2']
-      publish_to_marketplace: false
-      publish_to_community_galleries: true
       gallery_regions: ['northeurope', 'westeurope']
     - platform: 'gcp'
       gcp_cfg_name: 'gardenlinux-integration-test'


### PR DESCRIPTION
**What this PR does / why we need it**:

As Garden Linux is no longer published to the Azure Marketplace but to Azure Community Image Galleries instead (and this being the case since Garden Linux 934), this PR drops all code that was relevant for publishing the Azure Marketplace from glci.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Code that was used to publish Garden Linux to Azure Marketplace and that has become obsolete with the advent of Azure Community Image Galleries was removed from glci.
```
