### PR TITLE
fix: reading version file should not overwrite parsed args

### DIFF
--- a/.cicd-cli.py
+++ b/.cicd-cli.py
@@ -549,9 +549,9 @@ def publish_release_set():
             commit = publish_version.commit
     else:
         with open(parsed.version_file[0]) as f:
-            parsed = yaml.safe_load(f)
-            version = parsed['version']
-            commit = parsed['committish']
+            version_yaml = yaml.safe_load(f)
+            version = version_yaml['version']
+            commit = version_yaml['committish']
 
     cfg = _publishing_cfg(parsed)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a small bug that would overwrite the `parsed` args object containing the command line arguments when reading version and committish from a version file instead of the command line.
