### PR TITLE
Exclude indonesiacentral

### DIFF
--- a/glci/az.py
+++ b/glci/az.py
@@ -265,6 +265,7 @@ def _create_shared_image(
     # rm regions not yet supported (although they are returned by the subscription-client)
     regions -= {
         'brazilus',
+        'indonesiacentral',
         'jioindiacentral',
         'jioindiawest',
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Indonesia to the list of excluded regions for Azure