### PR TITLE
temporarily disable integration tests on AliCloud

### DIFF
--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -91,11 +91,11 @@
     ocm_repository: europe-docker.pkg.dev/sap-se-gcp-gardenlinux/tests
     overwrite_component_descriptor: true
   targets:
-    - platform: 'ali'
-      oss_bucket_name: 'gardenlinux-test-upload'
-      aliyun_region: 'eu-central-1'
-      aliyun_cfg_name: 'gardenlinux-integration-test'
-      copy_regions: ['eu-central-1', 'eu-west-1']
+    # - platform: 'ali'
+    #   oss_bucket_name: 'gardenlinux-test-upload'
+    #   aliyun_region: 'eu-central-1'
+    #   aliyun_cfg_name: 'gardenlinux-integration-test'
+    #   copy_regions: ['eu-central-1', 'eu-west-1']
     - platform: 'aws'
       aws_cfgs:
         - aws_cfg_name: 'gardenlinux-integration-test'


### PR DESCRIPTION
**What this PR does / why we need it**:

As publishing to AliCloud is showing some instabilities atm, this commit temporarily disables publishing images for integration tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
