### PR TITLE
Publish openstack images with UEFI property

### DIFF
--- a/publishing-cfg.yaml
+++ b/publishing-cfg.yaml
@@ -58,6 +58,7 @@
         vmware_ostype: debian10_64Guest
         hw_vif_model: vmxnet3
         hw_disk_bus: scsi
+        hw_firmware_type: uefi
         vmware_adaptertype: paraVirtual
         vmware_disktype: streamOptimized
     - platform: 'openstackbaremetal'
@@ -118,6 +119,7 @@
         vmware_ostype: debian10_64Guest
         hw_vif_model: vmxnet3
         hw_disk_bus: scsi
+        hw_firmware_type: uefi
         vmware_adaptertype: paraVirtual
         vmware_disktype: streamOptimized
     - platform: 'azure'


### PR DESCRIPTION
**What this PR does / why we need it**:

Publlishes OpenStack (_not_ openstack-baremetal) images with `hw_firmware_type: uefi` image property to make those images boot with UEFI firmware on OpenStack/VMware.
